### PR TITLE
PLAT-11326: return errors as JSON and others mini fixes

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/WorkflowsApiController.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/WorkflowsApiController.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.api.v1;
 
-import com.symphony.bdk.workflow.api.v1.dto.RequestReceivedDto;
+import com.symphony.bdk.workflow.api.v1.dto.ErrorResponse;
+import com.symphony.bdk.workflow.api.v1.dto.WorkflowExecutionRequest;
 import com.symphony.bdk.workflow.engine.ExecutionParameters;
 import com.symphony.bdk.workflow.engine.UnauthorizedException;
 import com.symphony.bdk.workflow.engine.WorkflowEngine;
@@ -32,8 +33,8 @@ public class WorkflowsApiController {
    * @param arguments Pass arguments to the event triggering the workflow
    */
   @PostMapping("/{id}/execute")
-  public ResponseEntity<String> executeWorkflowById(@RequestHeader(name = "X-Workflow-Token") String token,
-      @PathVariable String id, @RequestBody RequestReceivedDto arguments) {
+  public ResponseEntity<Object> executeWorkflowById(@RequestHeader(name = "X-Workflow-Token") String token,
+      @PathVariable String id, @RequestBody WorkflowExecutionRequest arguments) {
 
     try {
       log.info("Executing workflow {}", id);
@@ -41,11 +42,11 @@ public class WorkflowsApiController {
 
     } catch (IllegalArgumentException illegalArgumentException) {
       log.warn("The workflow id {} provided in the request does not exist", id);
-      return new ResponseEntity<>(illegalArgumentException.getMessage(), HttpStatus.NOT_FOUND);
+      return new ResponseEntity<>(new ErrorResponse(illegalArgumentException.getMessage()), HttpStatus.NOT_FOUND);
 
     } catch (UnauthorizedException unauthorizedException) {
       log.warn("The token provided in the request is not valid for this workflow");
-      return new ResponseEntity<>(unauthorizedException.getMessage(), HttpStatus.UNAUTHORIZED);
+      return new ResponseEntity<>(new ErrorResponse(unauthorizedException.getMessage()), HttpStatus.UNAUTHORIZED);
     }
 
     return ResponseEntity.noContent().build();

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/ErrorResponse.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/ErrorResponse.java
@@ -1,0 +1,8 @@
+package com.symphony.bdk.workflow.api.v1.dto;
+
+import lombok.Value;
+
+@Value
+public class ErrorResponse {
+  String message;
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/WorkflowExecutionRequest.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/WorkflowExecutionRequest.java
@@ -5,6 +5,6 @@ import lombok.Data;
 import java.util.Map;
 
 @Data
-public class RequestReceivedDto {
+public class WorkflowExecutionRequest {
   private Map<String, Object> args;
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngine.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngine.java
@@ -48,7 +48,7 @@ public class CamundaEngine implements WorkflowEngine {
       workflow.setId("workflow_" + UUID.randomUUID());
     }
     Deployment deployment = bpmnBuilder.addWorkflow(workflow);
-    log.info("Deployed workflow {}", deployment.getId());
+    log.info("Deployed workflow {} {}", deployment.getId(), deployment.getName());
     auditTrailLogger.deployed(deployment);
   }
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/api/v1/WorkflowsApiControllerIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/api/v1/WorkflowsApiControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.symphony.bdk.workflow.engine.ExecutionParameters;
@@ -81,14 +82,12 @@ class WorkflowsApiControllerIntegrationTest {
     doThrow(new IllegalArgumentException("No workflow found with id wfId")).when(workflowEngine)
         .execute(eq("wfId"), any(ExecutionParameters.class));
 
-    MvcResult mvcResult = mockMvc.perform(request(HttpMethod.POST, PATH)
+    mockMvc.perform(request(HttpMethod.POST, PATH)
             .header("X-Workflow-Token", "myToken")
             .contentType("application/json")
             .content("{\"args\": {\"content\":\"hello\"}}"))
         .andExpect(status().isNotFound())
-        .andReturn();
-
-    assertThat(mvcResult.getResponse().getContentAsString()).isEqualTo("No workflow found with id wfId");
+        .andExpect(jsonPath("$.message").value("No workflow found with id wfId"));
   }
 
   @Test
@@ -96,13 +95,11 @@ class WorkflowsApiControllerIntegrationTest {
     doThrow(new UnauthorizedException("Token is not valid")).when(workflowEngine)
         .execute(eq("wfId"), any(ExecutionParameters.class));
 
-    MvcResult mvcResult = mockMvc.perform(request(HttpMethod.POST, PATH)
+    mockMvc.perform(request(HttpMethod.POST, PATH)
             .header("X-Workflow-Token", "myToken")
             .contentType("application/json")
             .content("{\"args\": {\"content\":\"hello\"}}"))
         .andExpect(status().isUnauthorized())
-        .andReturn();
-
-    assertThat(mvcResult.getResponse().getContentAsString()).isEqualTo("Token is not valid");
+        .andExpect(jsonPath("$.message").value("Token is not valid"));
   }
 }

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1406,7 +1406,7 @@
                             "enum": [
                                 "${variables.VARIABLE_NAME}",
                                 "${text(ACTIVITY_ID.outputs.message.message)}",
-                                "${event.args.content}",
+                                "${event.args.NAME}",
                                 "<mention uid='${ACTIVITY_ID.outputs.user.userSystemInfo.id}'/>",
                                 "<mention uid='${event.initiator.user.userId}'/>"
                             ]
@@ -2622,19 +2622,12 @@
         },
         "user-ids-inner": {
             "description": "User identifiers list.",
-            "anyOf": [
-                {
-                    "enum": []
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/user-id"
-                    },
-                    "minLength": 1,
-                    "uniqueItems": true
-                }
-            ]
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/user-id"
+            },
+            "minLength": 1,
+            "uniqueItems": true
         },
         "user-ids": {
             "type": "object",


### PR DESCRIPTION
So we can eventually add error codes later, also easier to parse and
consistent with Spring errors.

---

Better deployment log 

Otherwise only the id (uuid) is printed.

---

Fix JSON schema for send-message.to.user-ids

Validation was broken with the empty enum.
Also do not assume how the args fields are named and use a placeholder.