### PR TITLE
PLAT-11355: make get-connections support null params

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionsExecutor.java
@@ -21,11 +21,22 @@ public class GetConnectionsExecutor implements ActivityExecutor<GetConnections> 
     GetConnections activity = context.getActivity();
 
     List<UserConnection> connections = context.bdk().connections()
-        .listConnections(ConnectionStatus.valueOf(activity.getStatus()), toLongs(activity.getUserIds()));
+        .listConnections(toConnectionStatus(activity.getStatus()), toLongs(activity.getUserIds()));
     context.setOutputVariable(OUTPUT_CONNECTIONS_KEY, connections);
   }
 
+  private ConnectionStatus toConnectionStatus(String statusString) {
+    if (statusString == null) {
+      return null;
+    }
+
+    return ConnectionStatus.valueOf(statusString);
+  }
+
   private static List<Long> toLongs(List<String> ids) {
+    if (ids == null) {
+      return null;
+    }
     return ids.stream().map(Long::parseLong).collect(Collectors.toList());
   }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ConnectionsIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ConnectionsIntegrationTest.java
@@ -47,6 +47,25 @@ class ConnectionsIntegrationTest extends IntegrationTest {
   }
 
   @Test
+  void listConnectionsNoParam() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/connection/get-connections-no-params.swadl.yaml"));
+
+    final List<UserConnection> userConnections = Arrays.asList(connection(666L, UserConnection.StatusEnum.ACCEPTED),
+        connection(777L, UserConnection.StatusEnum.ACCEPTED));
+
+    when(connectionService.listConnections(null, null)).thenReturn(userConnections);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/get-connections-no-params"));
+
+    verify(connectionService, timeout(5000)).listConnections(null, null);
+
+    assertThat(workflow).isExecuted()
+        .hasOutput(String.format(OUTPUTS_CONNECTIONS_KEY, "getConnections"), userConnections);
+  }
+
+  @Test
   @DisplayName("Given a connection with a user, when the workflow is triggered, then the connection is returned")
   void getConnectionStatus() throws IOException, ProcessingException {
     final Workflow workflow =

--- a/workflow-bot-app/src/test/resources/connection/get-connections-no-params.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/get-connections-no-params.swadl.yaml
@@ -1,0 +1,7 @@
+id: get-connections-no-params
+activities:
+  - get-connections:
+      id: getConnections
+      on:
+        message-received:
+          content: /get-connections-no-params

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/GetConnections.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/GetConnections.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * @see <a href="https://developers.symphony.com/restapi/reference#list-connections">List Connections API</a>
@@ -13,6 +14,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class GetConnections extends BaseActivity {
-  private List<String> userIds;
-  private String status;
+  @Nullable private List<String> userIds;
+  @Nullable private String status;
 }

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -2522,11 +2522,7 @@
                         "ALL"
                     ]
                 }
-            },
-            "required": [
-                "user-ids",
-                "status"
-            ]
+            }
         },
         "to": {
             "type": "object",


### PR DESCRIPTION
This was changed in  to adapt Java BDK 2.0 to the documented behaviour allowing the params to be null