### PR TITLE
Removed dependency to custom-activity-example in workflow-bot-app

### DIFF
--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
     implementation project(':workflow-language')
-    implementation project(':custom-activity-example')
 
     implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.2.1')
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RequestEventIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RequestEventIntegrationTest.java
@@ -3,7 +3,6 @@ package com.symphony.bdk.workflow;
 import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.content;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -19,13 +18,9 @@ import com.symphony.bdk.workflow.swadl.v1.Workflow;
 
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.stream.Stream;
 
 class RequestEventIntegrationTest extends IntegrationTest {
 
@@ -33,37 +28,52 @@ class RequestEventIntegrationTest extends IntegrationTest {
   void onRequestReceived() throws IOException, ProcessingException {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/event/request-received.swadl.yaml"));
-
     engine.deploy(workflow);
+
     engine.execute("my-workflow", new ExecutionParameters(Map.of("content", "Hello World!"), "myToken"));
+
     verify(messageService, timeout(5000).times(1)).send(eq("123"), content("Hello World!"));
   }
 
-  static Stream<Arguments> errorsStream() {
-    return Stream.of(
-        arguments("my-workflow", new ExecutionParameters(Map.of("content", "Hello World!"), "badToken"),
-            UnauthorizedException.class,
-            "Request token is not valid"),
-        arguments("my-workflow", new ExecutionParameters(Map.of("content", "Hello World!"), null),
-            UnauthorizedException.class,
-            "Request token is not valid"),
-        arguments("unfoundWorkflowId", new ExecutionParameters(Map.of("content", "Hello World!"), "myToken"),
-            IllegalArgumentException.class,
-            "No workflow found with id unfoundWorkflowId")
-    );
-  }
-
-  @ParameterizedTest
-  @MethodSource("errorsStream")
-  void onRequestReceived_badToken(String workflowId, ExecutionParameters executionParameters,
-      Class<? extends Throwable> expectedExceptionType, String errorMessage) throws IOException, ProcessingException {
+  @Test
+  void onRequestReceived_badToken() throws IOException, ProcessingException {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/event/request-received.swadl.yaml"));
 
     engine.deploy(workflow);
-    assertThatExceptionOfType(expectedExceptionType).isThrownBy(
-            () -> engine.execute(workflowId, executionParameters))
-        .satisfies(e -> assertThat(e.getMessage()).isEqualTo(errorMessage));
+
+    ExecutionParameters executionParameters = new ExecutionParameters(Map.of("content", "Hello World!"), "badToken");
+    assertThatExceptionOfType(UnauthorizedException.class).isThrownBy(
+            () -> engine.execute("my-workflow", executionParameters))
+        .satisfies(e -> assertThat(e.getMessage()).isEqualTo("Request token is not valid"));
+    verify(messageService, never()).send(anyString(), any(Message.class));
+  }
+
+  @Test
+  void onRequestReceived_tokenNull() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/event/request-received.swadl.yaml"));
+
+    engine.deploy(workflow);
+
+    ExecutionParameters executionParameters = new ExecutionParameters(Map.of("content", "Hello World!"), null);
+    assertThatExceptionOfType(UnauthorizedException.class).isThrownBy(
+            () -> engine.execute("my-workflow", executionParameters))
+        .satisfies(e -> assertThat(e.getMessage()).isEqualTo("Request token is not valid"));
+    verify(messageService, never()).send(anyString(), any(Message.class));
+  }
+
+  @Test
+  void onRequestReceived_badWorkflowId() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/event/request-received.swadl.yaml"));
+
+    engine.deploy(workflow);
+
+    ExecutionParameters executionParameters = new ExecutionParameters(Map.of("content", "Hello World!"), "myToken");
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+            () -> engine.execute("unfoundWorkflowId", executionParameters))
+        .satisfies(e -> assertThat(e.getMessage()).isEqualTo("No workflow found with id unfoundWorkflowId"));
     verify(messageService, never()).send(anyString(), any(Message.class));
   }
 


### PR DESCRIPTION
custom-activity-example module is not published on Maven central. workflow-bot-app having a dependency on it was making the project download fail.
For the same occasion, a small refactor in RequestEventsIntegrationTest for better readability.