### PR TITLE
PLAT-11148: Error handling

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,6 +39,10 @@ We are mainly interested in the `camunda.bpm.job-execution` properties to config
 workflows, for instance the wait time to detect new events to process. It is configured with a low value by default to
 ensure the bot is reactive.
 
+Camunda is configured to retry on activity/task errors. Part of the error handling is done via the BDK that already
+support retrying on failed API calls and then error handling can also be done when writing workflows with
+the [activity-failed event](./reference.md#activity-failed).
+
 ### Spring Boot specific configuration
 
 The [common application properties](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -557,11 +557,45 @@ activities:
 
 #### <a name="completed-activity-id"></a>activity-id
 
-The id of the activity which completion's triggers this event.
+The completed (without errors) activity triggering this event.
 
 #### <a name="completed-if"></a>if
 
 Similar to the [if](#if) at `on` level but applied to a single completed activity.
+
+### activity-failed
+
+Generated when the given activity has failed. **Note this is not a Datafeed real-time event.**
+
+Exceptions raised by activities will trigger this event. This gives a way to let the user know about a failure.
+
+Key | Type | Required |
+------------ | -------| --- | 
+[activity-id](#failed-activity-id) | String | Yes |
+
+Example:
+
+```yaml
+activities:
+  - send-message:
+      id: sendHello
+      on:
+        message-received:
+          content: /execute
+      to:
+        stream-id: NON_EXISTING_STREAM
+      content: Hello
+  - send-message:
+      id: errorHandling
+      on:
+        activity-failed:
+          activity-id: sendHello
+      content: Sending a message failed
+```
+
+#### <a name="failed-activity-id"></a>activity-id
+
+The failing activity triggering this event.
 
 ### timer-fired
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngineConfiguration.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngineConfiguration.java
@@ -1,8 +1,13 @@
 package com.symphony.bdk.workflow.engine.camunda;
 
+import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.delegate.BpmnError;
+import org.camunda.bpm.engine.delegate.VariableScope;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.camunda.bpm.engine.impl.scripting.ExecutableScript;
+import org.camunda.bpm.engine.impl.scripting.env.ScriptingEnvironment;
 import org.camunda.bpm.spring.boot.starter.configuration.Ordering;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,10 +16,13 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import javax.script.Bindings;
+import javax.script.ScriptEngine;
 import javax.sql.DataSource;
 
 @Configuration
 @Order(Ordering.DEFAULT_ORDER + 1)
+@Slf4j
 public class CamundaEngineConfiguration implements ProcessEnginePlugin {
 
   @Bean
@@ -35,11 +43,40 @@ public class CamundaEngineConfiguration implements ProcessEnginePlugin {
   @Override
   public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
     processEngineConfiguration.getExpressionManager().addFunctionMapper(new BdkFunctionMapper());
+
   }
 
   @Override
   public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    handleScriptExceptionsAsBpmnErrors(processEngineConfiguration);
+  }
 
+  // By default, script exceptions (except for BPMNError) are not failing the script task
+  // We change this behavior to wrap any script exception in a BpmnError to handle errors with activity-failed
+  private void handleScriptExceptionsAsBpmnErrors(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    ScriptingEnvironment scriptingEnvironment = processEngineConfiguration.getScriptingEnvironment();
+    processEngineConfiguration.setScriptingEnvironment(new ScriptingEnvironment(null, null, null) {
+      @Override
+      public Object execute(ExecutableScript script, VariableScope scope) {
+        try {
+          return scriptingEnvironment.execute(script, scope);
+        } catch (Exception e) {
+          log.error("Failed to execute script", e);
+          throw new BpmnError("FAILURE", e);
+        }
+      }
+
+      @Override
+      public Object execute(ExecutableScript script, VariableScope scope, Bindings bindings,
+          ScriptEngine scriptEngine) {
+        try {
+          return scriptingEnvironment.execute(script, scope, bindings, scriptEngine);
+        } catch (Exception e) {
+          log.error("Failed to execute script", e);
+          throw new BpmnError("FAILURE", e);
+        }
+      }
+    });
   }
 
   @Override

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.camunda.bpm.engine.variable.Variables;
@@ -79,6 +80,10 @@ public class CamundaExecutor implements JavaDelegate {
       auditTrailLogger.execute(execution, activity.getClass().getSimpleName());
       executor.execute(new CamundaActivityExecutorContext(execution, (BaseActivity) activity, event,
           resourceLoader, bdk));
+    } catch (Exception e) {
+      log.error(String.format("Activity %s from workflow %s failed",
+          execution.getActivityInstanceId(), execution.getProcessInstanceId()), e);
+      throw new BpmnError("FAILURE", e);
     } finally {
       clearMdc();
     }

--- a/workflow-bot-app/src/main/resources/application.yaml
+++ b/workflow-bot-app/src/main/resources/application.yaml
@@ -23,6 +23,8 @@ camunda:
       properties:
         # Avoid requests to the outside world
         telemetryReporterActivate: false
+    # Upon failures, do not retry, this is left to the workflow's developer to control
+    default-number-of-retries: 1
 
 # Spring boot configuration
 spring:

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ErrorIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ErrorIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.symphony.bdk.workflow;
+
+import static com.symphony.bdk.workflow.custom.assertion.Assertions.assertThat;
+import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.content;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.symphony.bdk.workflow.swadl.SwadlParser;
+import com.symphony.bdk.workflow.swadl.v1.Workflow;
+
+import org.junit.jupiter.api.Test;
+
+class ErrorIntegrationTest extends IntegrationTest {
+
+  @Test
+  void onActivityFailed() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/error/on-activity-failed.swadl.yaml"));
+    when(messageService.send(eq("STREAM"), content("On success"))).thenThrow(new RuntimeException("Failure"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/failure"));
+
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On failure"));
+    assertThat(workflow).executed("fallback");
+  }
+
+  @Test
+  void onActivityFailedContinue() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/error/on-activity-failed-continue.swadl.yaml"));
+    when(messageService.send(eq("STREAM"), content("On success"))).thenThrow(new RuntimeException("Failure"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/failure"));
+
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On failure"));
+    assertThat(workflow).executed("fallback");
+  }
+
+  @Test
+  void onActivityFailedContinue2() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/error/on-activity-failed-continue2.swadl.yaml"));
+    when(messageService.send(eq("STREAM"), content("On success"))).thenThrow(new RuntimeException("Failure"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/failure"));
+
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On failure"));
+    assertThat(workflow).executed("fallback");
+  }
+
+  @Test
+  void onActivityFailedContinueFailure() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/error/on-activity-failed-continue-failure.swadl.yaml"));
+    when(messageService.send(eq("STREAM"), content("On success"))).thenThrow(new RuntimeException("Failure"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/failure"));
+
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On failure"));
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On failure 2"));
+    assertThat(workflow).executed("continue", "continue2");
+  }
+
+  @Test
+  void onActivityFailed_notFailed() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/error/on-activity-failed.swadl.yaml"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/failure"));
+
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On success"));
+    assertThat(workflow).executed("failing");
+  }
+
+  @Test
+  void onActivityFailed_OneOf_SecondFails() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/error/on-activity-failed-one-of.swadl.yaml"));
+    when(messageService.send(eq("STREAM"), content("Second"))).thenThrow(new RuntimeException("Failure"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/failure"));
+
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On failure"));
+    assertThat(workflow).executed("first", "fallback");
+  }
+
+  @Test
+  void onActivityFailed_OneOf_FirstFails() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/error/on-activity-failed-one-of.swadl.yaml"));
+    when(messageService.send(eq("STREAM"), content("First"))).thenThrow(new RuntimeException("Failure"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/failure"));
+
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On failure"));
+    assertThat(workflow).executed("fallback");
+  }
+
+  @Test
+  void onScriptActivityFailed() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/error/on-script-activity-failed.swadl.yaml"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/failure"));
+
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On failure"));
+    assertThat(workflow).executed("fallback");
+  }
+
+  @Test
+  void onActivityFailedRetry() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/error/on-activity-failed-retry.swadl.yaml"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/failure"));
+
+    verify(messageService, timeout(5000)).send(eq("STREAM"), content("On failure"));
+    assertThat(workflow).executed("fallback", "failing");
+  }
+
+}

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
@@ -77,6 +77,12 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
     return this;
   }
 
+  public WorkflowAssert executed(String... activities) {
+    isNotNull();
+    assertExecuted(activities);
+    return this;
+  }
+
   public WorkflowAssert isExecutedWithProcessAndActivities(Optional<String> process, List<String> activities) {
     isNotNull();
     assertExecuted(process, activities);
@@ -162,6 +168,9 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
 
     org.assertj.core.api.Assertions.assertThat(processes)
         .filteredOn(p -> !p.getActivityType().equals("signalStartEvent"))
+        .filteredOn(p -> !p.getActivityType().equals("exclusiveGateway"))
+        .filteredOn(p -> !p.getActivityType().equals("boundaryError"))
+        .filteredOn(p -> !p.isCanceled())
         .extracting(HistoricActivityInstance::getActivityName)
         .containsExactly(activityIds);
   }

--- a/workflow-bot-app/src/test/resources/application-test.yaml
+++ b/workflow-bot-app/src/test/resources/application-test.yaml
@@ -8,7 +8,7 @@ logging:
   level:
     org.camunda: INFO
     # disable BPMN image generation
-    com.symphony.bdk.workflow.engine.camunda.bpmn.CamundaBpmnBuilder: INFO
+    com.symphony.bdk.workflow.engine.camunda.bpmn.CamundaBpmnBuilder: DEBUG
 
 # disable file watcher for tests
 workflows:

--- a/workflow-bot-app/src/test/resources/error/on-activity-failed-continue-failure.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/error/on-activity-failed-continue-failure.swadl.yaml
@@ -1,0 +1,25 @@
+id: on-activity-failed-continue-failure
+activities:
+  - send-message:
+      id: failing
+      on:
+        message-received:
+          content: /failure
+      to:
+        stream-id: STREAM
+      content: On success
+  - send-message:
+      id: continue
+      on:
+        activity-failed:
+          activity-id: failing
+      to:
+        stream-id: STREAM
+      content: On failure
+  - send-message:
+      # executed after continue, i.e. default sequential behavior
+      id: continue2
+      to:
+        stream-id: STREAM
+      content: On failure 2
+

--- a/workflow-bot-app/src/test/resources/error/on-activity-failed-continue.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/error/on-activity-failed-continue.swadl.yaml
@@ -1,0 +1,27 @@
+id: on-activity-failed-continue
+activities:
+  - send-message:
+      id: failing
+      on:
+        message-received:
+          content: /failure
+      to:
+        stream-id: STREAM
+      content: On success
+  - send-message:
+      id: fallback
+      on:
+        activity-failed:
+          activity-id: failing
+      to:
+        stream-id: STREAM
+      content: On failure
+  - send-message:
+      id: continue
+      on:
+        activity-completed:
+          # connect it back to first activity
+          activity-id: failing
+      to:
+        stream-id: STREAM
+      content: Will not be executed

--- a/workflow-bot-app/src/test/resources/error/on-activity-failed-continue2.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/error/on-activity-failed-continue2.swadl.yaml
@@ -1,0 +1,25 @@
+id: on-activity-failed-continue2
+activities:
+  - send-message:
+      id: failing
+      on:
+        message-received:
+          content: /failure
+      to:
+        stream-id: STREAM
+      content: On success
+  - send-message:
+      # automatically connected to first activity
+      id: continue
+      to:
+        stream-id: STREAM
+      content: Will not be executed
+  - send-message:
+      id: fallback
+      on:
+        activity-failed:
+          activity-id: failing
+      to:
+        stream-id: STREAM
+      content: On failure
+

--- a/workflow-bot-app/src/test/resources/error/on-activity-failed-one-of.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/error/on-activity-failed-one-of.swadl.yaml
@@ -1,0 +1,26 @@
+id: on-activity-failed-one-of
+activities:
+  - send-message:
+      id: first
+      on:
+        message-received:
+          content: /failure
+      to:
+        stream-id: STREAM
+      content: First
+  - send-message:
+      id: second
+      to:
+        stream-id: STREAM
+      content: Second
+  - send-message:
+      id: fallback
+      on:
+        one-of:
+          - activity-failed:
+              activity-id: first
+          - activity-failed:
+              activity-id: second
+      to:
+        stream-id: STREAM
+      content: On failure

--- a/workflow-bot-app/src/test/resources/error/on-activity-failed-retry.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/error/on-activity-failed-retry.swadl.yaml
@@ -1,0 +1,26 @@
+id: on-activity-failed-retry
+variables:
+  attempt: 0
+activities:
+  - execute-script:
+      id: failing
+      on:
+        one-of:
+          - message-received:
+              content: /failure
+          - activity-completed:
+              activity-id: fallback
+      # first execution will fail, but it will be executed one more time
+      script: |
+        if (variables.attempt == 0) {
+            variables.attempt++
+            throw new RuntimeException("Fail first time")
+        }
+  - send-message:
+      id: fallback
+      on:
+        activity-failed:
+          activity-id: failing
+      to:
+        stream-id: STREAM
+      content: On failure

--- a/workflow-bot-app/src/test/resources/error/on-activity-failed.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/error/on-activity-failed.swadl.yaml
@@ -1,0 +1,18 @@
+id: on-activity-failed
+activities:
+  - send-message:
+      id: failing
+      on:
+        message-received:
+          content: /failure
+      to:
+        stream-id: STREAM
+      content: On success
+  - send-message:
+      id: fallback
+      on:
+        activity-failed:
+          activity-id: failing
+      to:
+        stream-id: STREAM
+      content: On failure

--- a/workflow-bot-app/src/test/resources/error/on-script-activity-failed.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/error/on-script-activity-failed.swadl.yaml
@@ -1,0 +1,19 @@
+id: on-script-activity-failed
+activities:
+  - execute-script:
+      id: failing
+      on:
+        message-received:
+          content: /failure
+      to:
+        stream-id: STREAM
+      script: |
+        throw new RuntimeException("Failure")
+  - send-message:
+      id: fallback
+      on:
+        activity-failed:
+          activity-id: failing
+      to:
+        stream-id: STREAM
+      content: On failure

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/Event.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/Event.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.workflow.swadl.v1;
 
 import com.symphony.bdk.workflow.swadl.v1.event.ActivityCompletedEvent;
 import com.symphony.bdk.workflow.swadl.v1.event.ActivityExpiredEvent;
+import com.symphony.bdk.workflow.swadl.v1.event.ActivityFailedEvent;
 import com.symphony.bdk.workflow.swadl.v1.event.ConnectionAcceptedEvent;
 import com.symphony.bdk.workflow.swadl.v1.event.ConnectionRequestedEvent;
 import com.symphony.bdk.workflow.swadl.v1.event.FormRepliedEvent;
@@ -37,6 +38,8 @@ public class Event {
   private ActivityExpiredEvent activityExpired;
 
   private ActivityCompletedEvent activityCompleted;
+
+  private ActivityFailedEvent activityFailed;
 
   private MessageReceivedEvent messageReceived;
 

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/event/ActivityFailedEvent.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/event/ActivityFailedEvent.java
@@ -1,0 +1,11 @@
+package com.symphony.bdk.workflow.swadl.v1.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import javax.annotation.Nullable;
+
+@Data
+public class ActivityFailedEvent {
+  private String activityId;
+}

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -510,6 +510,9 @@
                             "$ref": "#/definitions/activity-completed-event"
                         },
                         {
+                            "$ref": "#/definitions/activity-failed-event"
+                        },
+                        {
                             "$ref": "#/definitions/message-received-event"
                         },
                         {
@@ -799,6 +802,18 @@
                 "activity-expired"
             ]
         },
+        "activity-failed-event": {
+            "type": "object",
+            "properties": {
+                "activity-failed": {
+                    "description": "Generated when the given activity has failed. Note this is not a Datafeed real-time event.",
+                    "$ref": "#/definitions/activity-failed-event-inner"
+                }
+            },
+            "required": [
+                "activity-failed"
+            ]
+        },
         "activity-completed-event": {
             "type": "object",
             "properties": {
@@ -833,6 +848,9 @@
                             },
                             {
                                 "$ref": "#/definitions/activity-completed-event"
+                            },
+                            {
+                                "$ref": "#/definitions/activity-failed-event"
                             },
                             {
                                 "$ref": "#/definitions/message-received-event"
@@ -1058,7 +1076,19 @@
             "type": "object",
             "properties": {
                 "activity-id": {
-                    "description": "The activity id that the expiration triggers this event.",
+                    "description": "The expiring activity triggering this event.",
+                    "$ref": "#/definitions/id"
+                }
+            },
+            "required": [
+                "activity-id"
+            ]
+        },
+        "activity-failed-event-inner": {
+            "type": "object",
+            "properties": {
+                "activity-id": {
+                    "description": "The failing activity triggering this event.",
                     "$ref": "#/definitions/id"
                 }
             },
@@ -1070,7 +1100,7 @@
             "type": "object",
             "properties": {
                 "activity-id": {
-                    "description": "The activity id that the completion triggers this event.",
+                    "description": "The completed (without errors) activity triggering this event.",
                     "$ref": "#/definitions/id"
                 }
             },


### PR DESCRIPTION
Retries have been disabled at Camunda level, so a failing activity/task
only fails one and is not retried (was 3 times by default).

It is up to the workflow write to handle errors (the BDK also retries
when calling API, that can solve intermetting network issues for
instance).

An on.activity-failed event has been added to support that, it is
similar to the activity-expired or activity-completed event.

Using one-of, an error handler activity can be set for multiple
activities. Supporting a generic/catch all error handler was not easy to
implement and raise questions for complex flows or forms (what is the
scope of the error handling then?) so it is not supported for now.

Script task (execute-script) are a bit different so a bit of a hack had
to be used to make sure all exceptions are also caught by
activity-failed events.