### PR TITLE
Support blast messages in send-message

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -683,9 +683,10 @@ user easy.
 Key | Type | Required |
 ------------ | -------| --- | 
 [stream-id](#stream-id) | String | Yes |
+[stream-ids](#stream-ids) | String | Yes |
 [user-ids](#user-ids) | Map | Yes |
 
-_If `to` is used then one of the key `stream-id` or `user-ids` must be set._
+_If `to` is used then one of the key `stream-id` or `stream-ids` or `user-ids` must be set._
 
 Example:
 
@@ -703,6 +704,10 @@ activities:
 ##### stream-id
 
 Stream id to send the message to. Both url safe and base64 encoded urls are accepted.
+
+##### stream-ids
+
+Stream ids to send the blast message to. Both url safe and base64 encoded urls are accepted.
 
 ##### user-ids
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
@@ -298,6 +298,17 @@ class SendMessageIntegrationTest extends IntegrationTest {
     assertThat(messageSent.getAttachments().size()).as("The sent message has 2 attachments").isEqualTo(2);
   }
 
+  @Test
+  void sendBlastMessage() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/send-blast-message.swadl.yaml"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/send-blast"));
+
+    verify(messageService, timeout(5000)).send(eq(List.of("ABC", "DEF")), any());
+  }
+
   private static byte[] mockBase64ByteArray() {
     String randomString = UUID.randomUUID().toString();
     return Base64.getEncoder().encode(randomString.getBytes(StandardCharsets.UTF_8));

--- a/workflow-bot-app/src/test/resources/message/send-blast-message.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/send-blast-message.swadl.yaml
@@ -1,0 +1,12 @@
+id: send-blast-message
+activities:
+  - send-message:
+      id: sendMessageWithUserIds
+      on:
+        message-received:
+          content: /send-blast
+      to:
+        stream-ids:
+          - ABC
+          - DEF
+      content: "<messageML>hello</messageML>"

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/SendMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/SendMessage.java
@@ -16,6 +16,7 @@ public class SendMessage extends BaseActivity {
   @Data
   public static class To {
     @Nullable private String streamId;
+    @Nullable private List<String> streamIds;
     @Nullable private List<String> userIds;
   }
 

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -2535,6 +2535,9 @@
                     "$ref": "#/definitions/stream-id"
                 },
                 {
+                    "$ref": "#/definitions/stream-ids"
+                },
+                {
                     "$ref": "#/definitions/user-ids"
                 }
             ]
@@ -2610,7 +2613,7 @@
         },
         "stream-id": {
             "type": "object",
-            "description": "Stream id to sent the message to",
+            "description": "Stream id to sent the message to.",
             "properties": {
                 "stream-id": {
                     "$ref": "#/definitions/stream-id-inner"
@@ -2618,6 +2621,23 @@
             },
             "required": [
                 "stream-id"
+            ]
+        },
+        "stream-ids": {
+            "type": "object",
+            "description": "Stream ids to sent the message to (blast message).",
+            "properties": {
+                "stream-ids": {
+                    "type": "array",
+                    "minLength": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "required": [
+                "stream-ids"
             ]
         },
         "user-ids-inner": {


### PR DESCRIPTION
We can now send a message to multiple rooms with a single call to the
send-message activity (i.e. blast).