### PR TITLE
Publish only fatjar bot app

### DIFF
--- a/buildSrc/src/main/groovy/workflow-bot.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/workflow-bot.java-conventions.gradle
@@ -60,7 +60,6 @@ tasks.matching { task -> task.name.startsWith('spotbugs') }.forEach {
 publishing {
     publications {
         maven(MavenPublication) {
-            from(components.java)
             pom {
                 url = 'https://github.com/SymphonyPlatformSolutions/symphony-wdk'
                 licenses {

--- a/workflow-language/build.gradle
+++ b/workflow-language/build.gradle
@@ -10,3 +10,11 @@ dependencies {
 
     api 'com.fasterxml.jackson.core:jackson-annotations:2.12.4'
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+        }
+    }
+}


### PR DESCRIPTION
The output of the workflow-bot-app module is the fatjar only, we don't
expect it to be a dependency from other projects, therefore we publish
the fatjar only.