### PR TITLE
PLAT-11401: Support variables usage for list/map attributes

### DIFF
--- a/docs/custom-activities.md
+++ b/docs/custom-activities.md
@@ -1,19 +1,22 @@
 # Implementing your own custom activity
 
-While the workflow bot comes with built in activities such as `send-message`, `create-room`,...,
-you might want to develop your own. To support this use case we provide a Java API that you can use to implement
-a custom activity.
-It can then be referenced from a workflow definition.
+While the workflow bot comes with built in activities such as `send-message`, `create-room`,..., you might want to
+develop your own. To support this use case we provide a Java API that you can use to implement a custom activity. It can
+then be referenced from a workflow definition.
 
 ## Defining a custom activity
 
-The _custom-activity-example_ folder at the root of the repository is a sample project where an activity 
-and its executor are defined.
+The _custom-activity-example_ folder at the root of the repository is a sample project where an activity and its
+executor are defined.
 
-[MyActivity](../custom-activity-example/src/main/java/org/acme/workflow/MyActivity.java) extends the `BaseActivity` 
+[MyActivity](../custom-activity-example/src/main/java/org/acme/workflow/MyActivity.java) extends the `BaseActivity`
 class that provides common attributes for an activity such as its id or its starting event (`on`).
-If you want to support variables being passed as attributes in SWADL (with the `${}` syntax) then the class fields
-must be typed as `String` (variables are evaluated at runtime).
+
+If you want to support variables being passed as attributes in SWADL (with the `${}` syntax) then the class fields must
+be typed as `Variable` (variables are evaluated at runtime, so we use wrapper to pass either a value or a variable
+reference). Supported types for attributes are: String, Boolean, Number, List or Map (that can be wrapped in
+a `Variable`). Check
+the [existing activities](../workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity) for examples.
 
 [MyActivityExecutor](../custom-activity-example/src/main/java/org/acme/workflow/MyActivityExecutor.java) implements the
 `ActivityExecutor` interface and gives access to the activity definition, variables, outputs and BDK services during the
@@ -21,7 +24,7 @@ activity execution. `ActivityExecutor` is a generic interface that holds the cor
 
 Those 2 classes are part of a project that could live on its own and only needs a compileOnly(Gradle)/provided(Maven)
 dependency on the `workflow-language` module. In the example a third-party dependency is used by the custom activity.
-The activity classes as well as other dependencies are packaged as an archive that is meant to be added to the 
+The activity classes as well as other dependencies are packaged as an archive that is meant to be added to the
 workflow's bot classpath.
 
 ## Running the workflow bot with custom activities
@@ -42,13 +45,13 @@ cp -r ../custom-activity-example/build/install/custom-activity-example/lib lib/
 java  -Dloader.path=./lib -jar build/libs/workflow-bot-app.jar
 ```
 
-Here we add a local folder `lib` to the classpath where the JAR file holding the custom activity and its dependencies 
+Here we add a local folder `lib` to the classpath where the JAR file holding the custom activity and its dependencies
 would be copied.
 
 ## Using the custom activity in a workflow
 
-_The JSON schema providing documentation and code completion when writing workflows lets you reference custom 
-activities. At runtime the custom activities will be added to the schema to validate the workflow upon submission and 
+_The JSON schema providing documentation and code completion when writing workflows lets you reference custom
+activities. At runtime the custom activities will be added to the schema to validate the workflow upon submission and
 let you know if the activity is not known before execution._
 
 Let's go back to the `custom-activity-example` project:
@@ -70,6 +73,6 @@ activities:
 ```
 
 Here the `my-activity` is automatically mapped to the `MyActivity` class (based on the name). As a `BaseActivity` it
-comes with the `id` and `on` attributes. `MyActivity` defines a custom attribute (`myParameter`) that is used in its 
-executor. The executor simply translates the custom attribute to camel case format and will send the message 
+comes with the `id` and `on` attributes. `MyActivity` defines a custom attribute (`myParameter`) that is used in its
+executor. The executor simply translates the custom attribute to camel case format and will send the message
 _CamelCase_.

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngine.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngine.java
@@ -5,6 +5,7 @@ import com.symphony.bdk.spring.events.RealTimeEvent;
 import com.symphony.bdk.workflow.engine.ExecutionParameters;
 import com.symphony.bdk.workflow.engine.UnauthorizedException;
 import com.symphony.bdk.workflow.engine.WorkflowEngine;
+import com.symphony.bdk.workflow.engine.camunda.audit.AuditTrailLogger;
 import com.symphony.bdk.workflow.engine.camunda.bpmn.CamundaBpmnBuilder;
 import com.symphony.bdk.workflow.swadl.exception.UniqueIdViolationException;
 import com.symphony.bdk.workflow.swadl.v1.Workflow;

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
@@ -1,16 +1,20 @@
 package com.symphony.bdk.workflow.engine.camunda;
 
 import com.symphony.bdk.workflow.engine.ResourceProvider;
+import com.symphony.bdk.workflow.engine.camunda.audit.AuditTrailLogger;
+import com.symphony.bdk.workflow.engine.camunda.variable.EscapedJsonVariableDeserializer;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.engine.executor.BdkGateway;
 import com.symphony.bdk.workflow.engine.executor.EventHolder;
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
@@ -43,7 +47,10 @@ public class CamundaExecutor implements JavaDelegate {
   private static final String MDC_ACTIVITY_ID = "ACTIVITY_ID";
 
   static {
+    SimpleModule module = new SimpleModule();
+    module.addDeserializer(Variable.class, new EscapedJsonVariableDeserializer());
     OBJECT_MAPPER = JsonMapper.builder()
+        .addModule(module)
         .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
         // to escape # or $ in message received content and still serialize it to JSON
         .configure(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true)

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/audit/AuditTrailLogger.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/audit/AuditTrailLogger.java
@@ -1,4 +1,4 @@
-package com.symphony.bdk.workflow.engine.camunda;
+package com.symphony.bdk.workflow.engine.camunda.audit;
 
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/audit/ScriptTaskAuditListener.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/audit/ScriptTaskAuditListener.java
@@ -1,6 +1,5 @@
-package com.symphony.bdk.workflow.engine.camunda.listener;
+package com.symphony.bdk.workflow.engine.camunda.audit;
 
-import com.symphony.bdk.workflow.engine.camunda.AuditTrailLogger;
 import com.symphony.bdk.workflow.swadl.v1.activity.ExecuteScript;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
@@ -2,8 +2,8 @@ package com.symphony.bdk.workflow.engine.camunda.bpmn;
 
 import com.symphony.bdk.workflow.engine.camunda.CamundaExecutor;
 import com.symphony.bdk.workflow.engine.camunda.WorkflowEventToCamundaEvent;
-import com.symphony.bdk.workflow.engine.camunda.listener.ScriptTaskAuditListener;
-import com.symphony.bdk.workflow.engine.camunda.listener.VariablesListener;
+import com.symphony.bdk.workflow.engine.camunda.audit.ScriptTaskAuditListener;
+import com.symphony.bdk.workflow.engine.camunda.variable.VariablesListener;
 import com.symphony.bdk.workflow.swadl.ActivityRegistry;
 import com.symphony.bdk.workflow.swadl.exception.ActivityNotFoundException;
 import com.symphony.bdk.workflow.swadl.exception.InvalidActivityException;

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/EscapedJsonVariableDeserializer.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/EscapedJsonVariableDeserializer.java
@@ -1,0 +1,81 @@
+package com.symphony.bdk.workflow.engine.camunda.variable;
+
+import static com.symphony.bdk.workflow.swadl.v1.Variable.RESOLVED_VALUE_FIELD;
+import static com.symphony.bdk.workflow.swadl.v1.Variable.VARIABLE_REFERENCE_FIELD;
+
+import com.symphony.bdk.workflow.swadl.v1.Variable;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Variables are serialized as escaped JSON by {@link VariableToJsonConverter} and passed to the executor.
+ * When the executor deserializes the activity to access the model, it uses this custom deserializer to
+ * recreate the {@link Variable} objects now containing resolved values.
+ */
+@SuppressWarnings("rawtypes")
+public class EscapedJsonVariableDeserializer extends StdDeserializer<Variable> {
+
+  public EscapedJsonVariableDeserializer() {
+    super(Variable.class);
+  }
+
+  @Override
+  public Variable deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    ObjectMapper mapper = (ObjectMapper) p.getCodec();
+    JsonNode node = mapper.readTree(p);
+
+    if (node.get(VARIABLE_REFERENCE_FIELD).isTextual()) {
+      // the variable has been resolved and is escaped JSON, parse it
+      try {
+        JsonNode tree = mapper.readTree(node.get(VARIABLE_REFERENCE_FIELD).textValue());
+
+        if (tree.isNumber()) {
+          return Variable.value(tree.numberValue());
+
+        } else if (tree.isBoolean()) {
+          return Variable.value(tree.booleanValue());
+
+        } else if (tree.isArray()) {
+          List variable = mapper.readValue(node.get(VARIABLE_REFERENCE_FIELD).textValue(), List.class);
+          return Variable.value(variable);
+
+        } else {
+          Map variable = mapper.readValue(node.get(VARIABLE_REFERENCE_FIELD).textValue(), Map.class);
+          return Variable.value(variable);
+        }
+      } catch (JsonProcessingException e) {
+        // cannot parse the escaped JSON as JSON, treat it as a simple string
+        return Variable.value(node.get(VARIABLE_REFERENCE_FIELD).textValue());
+      }
+
+      // the variable was already containing its value (no variable reference was used), read it directly
+    } else if (node.get(RESOLVED_VALUE_FIELD).isBoolean()) {
+      return Variable.value(node.get(RESOLVED_VALUE_FIELD).booleanValue());
+
+    } else if (node.get(RESOLVED_VALUE_FIELD).isNumber()) {
+      return Variable.value(node.get(RESOLVED_VALUE_FIELD).numberValue());
+
+    } else if (node.get(RESOLVED_VALUE_FIELD).isTextual()) {
+      return Variable.value(node.get(RESOLVED_VALUE_FIELD).textValue());
+
+    } else if (node.get(RESOLVED_VALUE_FIELD).isArray()) {
+      List variable = mapper.treeToValue(node.get(RESOLVED_VALUE_FIELD), List.class);
+      return Variable.value(variable);
+
+    } else {
+      Map variable = mapper.treeToValue(node.get(RESOLVED_VALUE_FIELD), Map.class);
+      return Variable.value(variable);
+    }
+  }
+
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/VariableToJsonConverter.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/VariableToJsonConverter.java
@@ -1,0 +1,40 @@
+package com.symphony.bdk.workflow.engine.camunda.variable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.camunda.bpm.engine.impl.javax.el.ELException;
+import org.camunda.bpm.engine.impl.juel.TypeConverterImpl;
+
+/**
+ * When variables are resolved in expressions, serialize the complex objects (lists, maps) as escaped JSON
+ * so they can be rebuilt to complex object when the model is deserialized and used in the executors.
+ *
+ * <p>This is used by the src/main/resources/el.properties file, loaded by
+ * {@link org.camunda.bpm.engine.impl.juel.ExpressionFactoryImpl}.
+ */
+public class VariableToJsonConverter extends TypeConverterImpl {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Override
+  protected String coerceToString(Object value) {
+    if (value == null) {
+      return "";
+    }
+    if (value instanceof String) {
+      return (String) value;
+    }
+    if (value instanceof Enum<?>) {
+      return ((Enum<?>) value).name();
+    }
+    try {
+      // the entire activity is serialized as JSON already, so we serialize the variable resolved value as escaped JSON.
+      String json = OBJECT_MAPPER.writeValueAsString(value);
+      char[] escapedJson = JsonStringEncoder.getInstance().quoteAsString(json);
+      return new String(escapedJson);
+    } catch (JsonProcessingException e) {
+      throw new ELException(e);
+    }
+  }
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/VariablesListener.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/VariablesListener.java
@@ -1,4 +1,4 @@
-package com.symphony.bdk.workflow.engine.camunda.listener;
+package com.symphony.bdk.workflow.engine.camunda.variable;
 
 import com.symphony.bdk.workflow.engine.camunda.CamundaExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
@@ -46,7 +46,6 @@ public class VariablesListener implements ExecutionListener {
 
       log.debug("Setting variables for execution {}", execution.getId());
       Map<String, Object> variablesAsMap = convertJsonStringToMap(variables.getValue(execution).toString());
-
       if (variablesAsMap != null) {
         log.debug("Loading workflow variable to execution context [{}]", variablesAsMap.keySet());
         execution.setVariable(ActivityExecutorContext.VARIABLES, variablesAsMap);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/SendMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/SendMessageExecutor.java
@@ -74,11 +74,11 @@ public class SendMessageExecutor implements ActivityExecutor<SendMessage> {
       return singletonList(activity.getTo().getStreamId());
 
     } else if (activity.getTo() != null && activity.getTo().getStreamIds() != null) {
-      return activity.getTo().getStreamIds();
+      return activity.getTo().getStreamIds().get();
 
     } else if (activity.getTo() != null && activity.getTo().getUserIds() != null) {
       // or the user ids are set explicitly in the workflow
-      return singletonList(this.createOrGetStreamId(activity.getTo().getUserIds(), streamService));
+      return singletonList(this.createOrGetStreamId(activity.getTo().getUserIds().get(), streamService));
 
     } else if (execution.getEvent() != null
         && execution.getEvent().getSource() instanceof V4MessageSent) {
@@ -97,9 +97,8 @@ public class SendMessageExecutor implements ActivityExecutor<SendMessage> {
     }
   }
 
-  private String createOrGetStreamId(List<String> userIds, StreamService streamService) {
-    List<Long> userIdsAsLong = userIds.stream().map(Long::parseLong).collect(Collectors.toList());
-    Stream stream = streamService.create(userIdsAsLong);
+  private String createOrGetStreamId(List<Number> userIds, StreamService streamService) {
+    Stream stream = streamService.create(userIds.stream().map(Number::longValue).collect(Collectors.toList()));
     return stream.getId();
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionsExecutor.java
@@ -21,11 +21,13 @@ public class GetConnectionsExecutor implements ActivityExecutor<GetConnections> 
     GetConnections activity = context.getActivity();
 
     List<UserConnection> connections = context.bdk().connections()
-        .listConnections(ConnectionStatus.valueOf(activity.getStatus()), toLongs(activity.getUserIds()));
+        .listConnections(ConnectionStatus.valueOf(activity.getStatus()), toLongs(activity.getUserIds().get()));
     context.setOutputVariable(OUTPUT_CONNECTIONS_KEY, connections);
   }
 
-  private static List<Long> toLongs(List<String> ids) {
-    return ids.stream().map(Long::parseLong).collect(Collectors.toList());
+  private static List<Long> toLongs(List<Number> ids) {
+    return ids.stream()
+        .map(Number::longValue)
+        .collect(Collectors.toList());
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/GetMessagesExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/GetMessagesExecutor.java
@@ -29,7 +29,7 @@ public class GetMessagesExecutor implements ActivityExecutor<GetMessages> {
     log.debug("Get messages by stream id {} since {}", streamId, activity.getSince());
 
     if (streamId != null && activity.getSince() != null) {
-      PaginationAttribute pagination = this.buildPagination(activity.getSkipAsInt(), activity.getLimitAsInt());
+      PaginationAttribute pagination = this.buildPagination(activity.getSkip().get(), activity.getLimit().get());
 
       if (pagination != null) {
         context.setOutputVariable(OUTPUT_MESSAGES_KEY,
@@ -41,9 +41,9 @@ public class GetMessagesExecutor implements ActivityExecutor<GetMessages> {
     }
   }
 
-  private PaginationAttribute buildPagination(Integer skip, Integer limit) {
+  private PaginationAttribute buildPagination(Number skip, Number limit) {
     if (skip != null && limit != null) {
-      return new PaginationAttribute(skip, limit);
+      return new PaginationAttribute(skip.intValue(), limit.intValue());
     }
     return null;
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/AddRoomMemberExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/AddRoomMemberExecutor.java
@@ -13,9 +13,9 @@ public class AddRoomMemberExecutor implements ActivityExecutor<AddRoomMember> {
   public void execute(ActivityExecutorContext<AddRoomMember> execution) {
     AddRoomMember addRoomMember = execution.getActivity();
 
-    for (String uid : addRoomMember.getUserIds()) {
+    for (Number uid : addRoomMember.getUserIds().get()) {
       log.debug("Add user {} to room {}", uid, addRoomMember.getStreamId());
-      execution.bdk().streams().addMemberToRoom(Long.valueOf(uid), addRoomMember.getStreamId());
+      execution.bdk().streams().addMemberToRoom(uid.longValue(), addRoomMember.getStreamId());
     }
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/CreateRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/CreateRoomExecutor.java
@@ -23,7 +23,7 @@ public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
     List<Long> uids = activity.getUserIdsAsLongs();
     String name = activity.getRoomName();
     String description = activity.getRoomDescription();
-    boolean isPublic = activity.isPublicAsBool();
+    Boolean isPublic = activity.getIsPublic().get();
 
     final String createdRoomId;
 
@@ -46,7 +46,7 @@ public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
     return stream.getId();
   }
 
-  private String createRoom(ActivityExecutorContext execution, String name, String description, boolean isPublic) {
+  private String createRoom(ActivityExecutorContext execution, String name, String description, Boolean isPublic) {
     V3RoomAttributes v3RoomAttributes = new V3RoomAttributes();
     v3RoomAttributes.name(name).description(description)._public(isPublic);
     V3RoomDetail v3RoomDetail = execution.bdk().streams().create(v3RoomAttributes);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/DemoteRoomOwnerExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/DemoteRoomOwnerExecutor.java
@@ -13,9 +13,9 @@ public class DemoteRoomOwnerExecutor implements ActivityExecutor<DemoteRoomOwner
   public void execute(ActivityExecutorContext<DemoteRoomOwner> execution) {
     DemoteRoomOwner demoteRoomOwner = execution.getActivity();
 
-    for (String uid : demoteRoomOwner.getUserIds()) {
+    for (Number uid : demoteRoomOwner.getUserIds().get()) {
       log.debug("Demote owner {} for room {}", uid, demoteRoomOwner.getStreamId());
-      execution.bdk().streams().demoteUserToRoomParticipant(Long.valueOf(uid), demoteRoomOwner.getStreamId());
+      execution.bdk().streams().demoteUserToRoomParticipant(uid.longValue(), demoteRoomOwner.getStreamId());
     }
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomsExecutor.java
@@ -21,10 +21,10 @@ public class GetRoomsExecutor implements ActivityExecutor<GetRooms> {
 
     GetRooms getRooms = execution.getActivity();
     V3RoomSearchResults rooms;
-    if (getRooms.getLimitAsInt() != null && getRooms.getSkipAsInt() != null) {
+    if (getRooms.getLimit() != null && getRooms.getSkip() != null) {
       rooms = execution.bdk().streams().searchRooms(toCriteria(getRooms),
-          new PaginationAttribute(getRooms.getSkipAsInt(), getRooms.getLimitAsInt()));
-    } else if (getRooms.getLimitAsInt() == null && getRooms.getSkipAsInt() == null) {
+          new PaginationAttribute(getRooms.getSkip().getInt(), getRooms.getLimit().getInt()));
+    } else if (getRooms.getLimit() == null && getRooms.getSkip() == null) {
       rooms = execution.bdk().streams().searchRooms(toCriteria(getRooms));
     } else {
       throw new IllegalArgumentException(
@@ -37,9 +37,9 @@ public class GetRoomsExecutor implements ActivityExecutor<GetRooms> {
   private V2RoomSearchCriteria toCriteria(GetRooms getRooms) {
     V2RoomSearchCriteria criteria = new V2RoomSearchCriteria()
         .query(getRooms.getQuery())
-        .labels(getRooms.getLabels())
-        ._private(getRooms.getIsPrivateAsBool())
-        .active(getRooms.getActiveAsBool());
+        .labels(getRooms.getLabels().get())
+        ._private(getRooms.getIsPrivate().get())
+        .active(getRooms.getActive().get());
     if (getRooms.getSortOrder() != null) {
       criteria.setSortOrder(V2RoomSearchCriteria.SortOrderEnum.fromValue(getRooms.getSortOrder()));
     }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/PromoteRoomOwnerExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/PromoteRoomOwnerExecutor.java
@@ -13,9 +13,9 @@ public class PromoteRoomOwnerExecutor implements ActivityExecutor<PromoteRoomOwn
   public void execute(ActivityExecutorContext<PromoteRoomOwner> execution) {
     PromoteRoomOwner promoteRoomOwner = execution.getActivity();
 
-    for (String uid : promoteRoomOwner.getUserIds()) {
+    for (Number uid : promoteRoomOwner.getUserIds().get()) {
       log.debug("Demote owner {} for room {}", uid, promoteRoomOwner.getStreamId());
-      execution.bdk().streams().promoteUserToRoomOwner(Long.valueOf(uid), promoteRoomOwner.getStreamId());
+      execution.bdk().streams().promoteUserToRoomOwner(uid.longValue(), promoteRoomOwner.getStreamId());
     }
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/RemoveRoomMemberExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/RemoveRoomMemberExecutor.java
@@ -13,9 +13,9 @@ public class RemoveRoomMemberExecutor implements ActivityExecutor<RemoveRoomMemb
   public void execute(ActivityExecutorContext<RemoveRoomMember> execution) {
     RemoveRoomMember removeRoomMember = execution.getActivity();
 
-    for (String uid : removeRoomMember.getUserIds()) {
+    for (Number uid : removeRoomMember.getUserIds().get()) {
       log.debug("Remove member {} from room {}", uid, removeRoomMember.getStreamId());
-      execution.bdk().streams().removeMemberFromRoom(Long.valueOf(uid), removeRoomMember.getStreamId());
+      execution.bdk().streams().removeMemberFromRoom(uid.longValue(), removeRoomMember.getStreamId());
     }
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
@@ -27,10 +27,10 @@ public class UpdateRoomExecutor implements ActivityExecutor<UpdateRoom> {
       execution.bdk().streams().updateRoom(updateRoom.getStreamId(), attributes);
     }
 
-    if (updateRoom.getActiveAsBool() != null) {
+    if (updateRoom.getActive() != null) {
       // this is a different API call but we support it in the same activity
       log.debug("Updating room {} active status", updateRoom.getStreamId());
-      execution.bdk().streams().setRoomActive(updateRoom.getStreamId(), updateRoom.getActiveAsBool());
+      execution.bdk().streams().setRoomActive(updateRoom.getStreamId(), updateRoom.getActive().get());
     }
 
     // services called above return different results and might end up not being called so we explicitly call the API
@@ -45,14 +45,14 @@ public class UpdateRoomExecutor implements ActivityExecutor<UpdateRoom> {
     return updateRoom.getRoomName() != null
         || updateRoom.getRoomDescription() != null
         || updateRoom.getKeywords() != null
-        || updateRoom.getMembersCanInviteAsBool() != null
-        || updateRoom.getDiscoverableAsBool() != null
-        || updateRoom.getIsPublicAsBool() != null
-        || updateRoom.getReadOnlyAsBool() != null
-        || updateRoom.getCopyProtectedAsBool() != null
-        || updateRoom.getCrossPodAsBool() != null
-        || updateRoom.getViewHistoryAsBool() != null
-        || updateRoom.getMultilateralRoomAsBool() != null;
+        || updateRoom.getMembersCanInvite().get() != null
+        || updateRoom.getDiscoverable().get() != null
+        || updateRoom.getIsPublic().get() != null
+        || updateRoom.getReadOnly().get() != null
+        || updateRoom.getCopyProtected().get() != null
+        || updateRoom.getCrossPod().get() != null
+        || updateRoom.getViewHistory().get() != null
+        || updateRoom.getMultilateralRoom().get() != null;
   }
 
   private V3RoomAttributes toAttributes(UpdateRoom updateRoom) {
@@ -61,7 +61,7 @@ public class UpdateRoomExecutor implements ActivityExecutor<UpdateRoom> {
     attributes.setDescription(updateRoom.getRoomDescription());
 
     if (updateRoom.getKeywords() != null) {
-      List<RoomTag> tags = updateRoom.getKeywords().entrySet().stream()
+      List<RoomTag> tags = updateRoom.getKeywords().get().entrySet().stream()
           .map(e -> {
             RoomTag tag = new RoomTag();
             tag.setKey(e.getKey());
@@ -72,14 +72,14 @@ public class UpdateRoomExecutor implements ActivityExecutor<UpdateRoom> {
       attributes.setKeywords(tags);
     }
 
-    attributes.membersCanInvite(updateRoom.getMembersCanInviteAsBool());
-    attributes.setDiscoverable(updateRoom.getDiscoverableAsBool());
-    attributes.setPublic(updateRoom.getIsPublicAsBool());
-    attributes.setReadOnly(updateRoom.getReadOnlyAsBool());
-    attributes.copyProtected(updateRoom.getCopyProtectedAsBool());
-    attributes.crossPod(updateRoom.getCrossPodAsBool());
-    attributes.viewHistory(updateRoom.getViewHistoryAsBool());
-    attributes.multiLateralRoom(updateRoom.getMultilateralRoomAsBool());
+    attributes.membersCanInvite(updateRoom.getMembersCanInvite().get());
+    attributes.setDiscoverable(updateRoom.getDiscoverable().get());
+    attributes.setPublic(updateRoom.getIsPublic().get());
+    attributes.setReadOnly(updateRoom.getReadOnly().get());
+    attributes.copyProtected(updateRoom.getCopyProtected().get());
+    attributes.crossPod(updateRoom.getCrossPod().get());
+    attributes.viewHistory(updateRoom.getViewHistory().get());
+    attributes.multiLateralRoom(updateRoom.getMultilateralRoom().get());
 
     return attributes;
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetStreamMembersExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetStreamMembersExecutor.java
@@ -20,10 +20,10 @@ public class GetStreamMembersExecutor implements ActivityExecutor<GetStreamMembe
 
     log.debug("Getting stream members for stream {}", streamId);
     V2MembershipList members;
-    if (getStreamMembers.getLimitAsInt() != null && getStreamMembers.getSkipAsInt() != null) {
+    if (getStreamMembers.getLimit() != null && getStreamMembers.getSkip() != null) {
       members = execution.bdk().streams().listStreamMembers(streamId,
-          new PaginationAttribute(getStreamMembers.getSkipAsInt(), getStreamMembers.getLimitAsInt()));
-    } else if (getStreamMembers.getLimitAsInt() == null && getStreamMembers.getSkipAsInt() == null) {
+          new PaginationAttribute(getStreamMembers.getSkip().getInt(), getStreamMembers.getLimit().getInt()));
+    } else if (getStreamMembers.getLimit() == null && getStreamMembers.getSkip() == null) {
       members = execution.bdk().streams().listStreamMembers(streamId);
     } else {
       throw new IllegalArgumentException(

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetStreamsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetStreamsExecutor.java
@@ -24,10 +24,10 @@ public class GetStreamsExecutor implements ActivityExecutor<GetStreams> {
 
     GetStreams getStreams = execution.getActivity();
     V2AdminStreamList streams;
-    if (getStreams.getLimitAsInt() != null && getStreams.getSkipAsInt() != null) {
+    if (getStreams.getLimit() != null && getStreams.getSkip() != null) {
       streams = execution.bdk().streams().listStreamsAdmin(toFilter(getStreams),
-          new PaginationAttribute(getStreams.getSkipAsInt(), getStreams.getLimitAsInt()));
-    } else if (getStreams.getLimitAsInt() == null && getStreams.getSkipAsInt() == null) {
+          new PaginationAttribute(getStreams.getSkip().getInt(), getStreams.getLimit().getInt()));
+    } else if (getStreams.getLimit() == null && getStreams.getSkip() == null) {
       streams = execution.bdk().streams().listStreamsAdmin(toFilter(getStreams));
     } else {
       throw new IllegalArgumentException(
@@ -47,7 +47,7 @@ public class GetStreamsExecutor implements ActivityExecutor<GetStreams> {
         .endDate(DateTimeUtils.toEpochMilli(getRooms.getEndDate()));
     if (getRooms.getTypes() != null) {
       filter.setStreamTypes(
-          getRooms.getTypes().stream().map(t -> new V2AdminStreamType().type(t)).collect(Collectors.toList()));
+          getRooms.getTypes().get().stream().map(t -> new V2AdminStreamType().type(t)).collect(Collectors.toList()));
     }
     return filter;
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetUserStreamsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetUserStreamsExecutor.java
@@ -24,9 +24,9 @@ public class GetUserStreamsExecutor implements ActivityExecutor<GetUserStreams> 
 
     GetUserStreams getUserStreams = execution.getActivity();
     List<StreamAttributes> userStreams;
-    if (getUserStreams.getLimitAsInt() != null && getUserStreams.getSkipAsInt() != null) {
+    if (getUserStreams.getLimit() != null && getUserStreams.getSkip() != null) {
       userStreams = execution.bdk().streams().listStreams(toFilter(getUserStreams),
-          new PaginationAttribute(getUserStreams.getSkipAsInt(), getUserStreams.getLimitAsInt()));
+          new PaginationAttribute(getUserStreams.getSkip().getInt(), getUserStreams.getLimit().getInt()));
     } else {
       userStreams = execution.bdk().streams().listStreams(toFilter(getUserStreams));
     }
@@ -36,10 +36,10 @@ public class GetUserStreamsExecutor implements ActivityExecutor<GetUserStreams> 
 
   private StreamFilter toFilter(GetUserStreams getUserStreams) {
     StreamFilter filter = new StreamFilter()
-        .includeInactiveStreams(getUserStreams.getIncludeInactiveStreamsAsBool());
+        .includeInactiveStreams(getUserStreams.getIncludeInactiveStreams().get());
 
     if (getUserStreams.getTypes() != null) {
-      filter.setStreamTypes(getUserStreams.getTypes().stream()
+      filter.setStreamTypes(getUserStreams.getTypes().get().stream()
           .map(t -> new StreamType().type(StreamType.TypeEnum.fromValue(t)))
           .collect(Collectors.toList()));
     }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/AddUserRoleExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/AddUserRoleExecutor.java
@@ -17,10 +17,10 @@ public class AddUserRoleExecutor implements ActivityExecutor<AddUserRole> {
   public void execute(ActivityExecutorContext<AddUserRole> context) {
     AddUserRole userRole = context.getActivity();
 
-    for (String userId : userRole.getUserIds()) {
-      for (String role : userRole.getRoles()) {
+    for (Number userId : userRole.getUserIds().get()) {
+      for (String role : userRole.getRoles().get()) {
         log.debug("Adding role {} to user {}", role, userId);
-        context.bdk().users().addRole(Long.valueOf(userId), RoleId.valueOf(role));
+        context.bdk().users().addRole(userId.longValue(), RoleId.valueOf(role));
       }
     }
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/CreateUserExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/CreateUserExecutor.java
@@ -38,9 +38,9 @@ public class CreateUserExecutor implements ActivityExecutor<CreateUser> {
     V2UserDetail createdUser = userService.create(toUser(createUser));
 
     Long userId = createdUser.getUserSystemInfo().getId();
-    if (createUser.getEntitlements() != null && !createUser.getEntitlements().isEmpty()) {
+    if (createUser.getEntitlements() != null && !createUser.getEntitlements().get().isEmpty()) {
       log.debug("Updating entitlements for user {}", userId);
-      userService.updateFeatureEntitlements(userId, toFeatures(createUser.getEntitlements()));
+      userService.updateFeatureEntitlements(userId, toFeatures(createUser.getEntitlements().get()));
     }
 
     if (createUser.getStatus() != null) {
@@ -70,7 +70,7 @@ public class CreateUserExecutor implements ActivityExecutor<CreateUser> {
       );
     }
 
-    user.setRoles(createUser.getRoles());
+    user.setRoles(createUser.getRoles().get());
     return user;
   }
 
@@ -98,12 +98,12 @@ public class CreateUserExecutor implements ActivityExecutor<CreateUser> {
       attributes.setCompanyName(createUser.getBusiness().getCompanyName());
       attributes.setJobFunction(createUser.getBusiness().getJobFunction());
       attributes.setTitle(createUser.getBusiness().getTitle());
-      attributes.setAssetClasses(createUser.getBusiness().getAssetClasses());
-      attributes.setFunction(createUser.getBusiness().getFunctions());
-      attributes.setIndustries(createUser.getBusiness().getIndustries());
-      attributes.setInstrument(createUser.getBusiness().getInstruments());
-      attributes.setResponsibility(createUser.getBusiness().getResponsibilities());
-      attributes.setMarketCoverage(createUser.getBusiness().getMarketCoverages());
+      attributes.setAssetClasses(createUser.getBusiness().getAssetClasses().get());
+      attributes.setFunction(createUser.getBusiness().getFunctions().get());
+      attributes.setIndustries(createUser.getBusiness().getIndustries().get());
+      attributes.setInstrument(createUser.getBusiness().getInstruments().get());
+      attributes.setResponsibility(createUser.getBusiness().getResponsibilities().get());
+      attributes.setMarketCoverage(createUser.getBusiness().getMarketCoverages().get());
     }
 
     if (createUser.getKeys() != null) {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/GetUsersExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/GetUsersExecutor.java
@@ -25,25 +25,25 @@ public class GetUsersExecutor implements ActivityExecutor<GetUsers> {
 
     // Since the workflow is validated by swadl-schema, at least one of the following attributes is not null
     if (getUsers.getUsernames() != null) {
-      users = context.bdk().users().listUsersByUsernames(getUsers.getUsernames(), getUsers.getActiveAsBool());
+      users = context.bdk().users().listUsersByUsernames(getUsers.getUsernames().get(), getUsers.getActive().get());
 
     } else if (getUsers.getUserIds() != null) {
       users = context.bdk()
           .users()
-          .listUsersByIds(toLongs(getUsers.getUserIds()), getUsers.getLocalAsBool(), getUsers.getActiveAsBool());
+          .listUsersByIds(toLongs(getUsers.getUserIds().get()), getUsers.getLocal().get(), getUsers.getActive().get());
 
     } else if (getUsers.getEmails() != null) {
       users = context.bdk()
           .users()
-          .listUsersByEmails(getUsers.getEmails(), getUsers.getLocalAsBool(), getUsers.getActiveAsBool());
+          .listUsersByEmails(getUsers.getEmails().get(), getUsers.getLocal().get(), getUsers.getActive().get());
 
     }
 
     context.setOutputVariable(OUTPUT_USERS_KEY, users);
   }
 
-  private List<Long> toLongs(List<String> ids) {
-    return ids.stream().map(Long::parseLong).collect(Collectors.toList());
+  private List<Long> toLongs(List<Number> ids) {
+    return ids.stream().map(Number::longValue).collect(Collectors.toList());
   }
 
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/RemoveUserRoleExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/RemoveUserRoleExecutor.java
@@ -17,10 +17,10 @@ public class RemoveUserRoleExecutor implements ActivityExecutor<RemoveUserRole> 
   public void execute(ActivityExecutorContext<RemoveUserRole> context) {
     RemoveUserRole userRole = context.getActivity();
 
-    for (String userId : userRole.getUserIds()) {
-      for (String role : userRole.getRoles()) {
+    for (Number userId : userRole.getUserIds().get()) {
+      for (String role : userRole.getRoles().get()) {
         log.debug("Removing role {} from user {}", role, userId);
-        context.bdk().users().removeRole(Long.valueOf(userId), RoleId.valueOf(role));
+        context.bdk().users().removeRole(userId.longValue(), RoleId.valueOf(role));
       }
     }
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/UpdateUserExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/UpdateUserExecutor.java
@@ -33,9 +33,9 @@ public class UpdateUserExecutor implements ActivityExecutor<UpdateUser> {
       userService.update(userId, CreateUserExecutor.toUserAttributes(updateUser));
     }
 
-    if (updateUser.getEntitlements() != null && !updateUser.getEntitlements().isEmpty()) {
+    if (updateUser.getEntitlements() != null && !updateUser.getEntitlements().get().isEmpty()) {
       log.debug("Updating entitlements for user {}", userId);
-      userService.updateFeatureEntitlements(userId, CreateUserExecutor.toFeatures(updateUser.getEntitlements()));
+      userService.updateFeatureEntitlements(userId, CreateUserExecutor.toFeatures(updateUser.getEntitlements().get()));
     }
 
     if (updateUser.getStatus() != null) {
@@ -71,16 +71,16 @@ public class UpdateUserExecutor implements ActivityExecutor<UpdateUser> {
     return business != null
         && business.getDepartment() != null
         && business.getCompanyName() != null
-        && business.getAssetClasses() != null
+        && business.getAssetClasses().get() != null
         && business.getDivision() != null
-        && business.getFunctions() != null
-        && business.getIndustries() != null
-        && business.getInstruments() != null
+        && business.getFunctions().get() != null
+        && business.getIndustries().get() != null
+        && business.getInstruments().get() != null
         && business.getLocation() != null
         && business.getJobFunction() != null
-        && business.getMarketCoverages() != null
+        && business.getMarketCoverages().get() != null
         && business.getTitle() != null
-        && business.getResponsibilities() != null;
+        && business.getResponsibilities().get() != null;
   }
 
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/swadl/SwadlParser.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/swadl/SwadlParser.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.workflow.swadl;
 
 
 import com.symphony.bdk.workflow.swadl.v1.Activity;
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.Workflow;
 import com.symphony.bdk.workflow.swadl.validator.SwadlValidator;
 
@@ -30,6 +31,7 @@ public class SwadlParser {
     MAPPER.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
     SimpleModule module = new SimpleModule();
     module.addDeserializer(Activity.class, new ActivityDeserializer());
+    module.addDeserializer(Variable.class, new VariableListDeserializer());
     MAPPER.registerModule(module);
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/swadl/VariableListDeserializer.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/swadl/VariableListDeserializer.java
@@ -1,0 +1,55 @@
+package com.symphony.bdk.workflow.swadl;
+
+import com.symphony.bdk.workflow.swadl.v1.Variable;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * To support SWADL to model deserialization using either variable references (${}) or
+ * values (lists, maps, strings, numbers).
+ */
+@SuppressWarnings("rawtypes")
+public class VariableListDeserializer extends StdDeserializer<Variable> {
+
+  public VariableListDeserializer() {
+    super(Variable.class);
+  }
+
+  @Override
+  public Variable deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    ObjectMapper mapper = (ObjectMapper) p.getCodec();
+    JsonNode node = mapper.readTree(p);
+
+    if (node.isTextual()) {
+      // this is a variable reference, keep it as such
+      return new Variable<>(node.asText());
+
+      // otherwise, store the value directly
+    } else if (node.isBoolean()) {
+      return Variable.value(node.booleanValue());
+
+    } else if (node.isNumber()) {
+      return Variable.value(node.numberValue());
+
+    } else if (node.isArray()) {
+      return Variable.value(mapper.treeToValue(node, List.class));
+
+    } else if (node.isObject()) {
+      return Variable.value(mapper.treeToValue(node, Map.class));
+
+    } else {
+      throw JsonMappingException.from(p,
+          "Unsupported type for attribute (not a variable reference or a list/map/boolean/number/string)");
+    }
+  }
+
+}

--- a/workflow-bot-app/src/main/resources/el.properties
+++ b/workflow-bot-app/src/main/resources/el.properties
@@ -1,0 +1,2 @@
+# Customize serialization of variables when expression are resolved to support complex types (list, map)
+org.camunda.bpm.engine.impl.juel.TypeConverter=com.symphony.bdk.workflow.engine.camunda.variable.VariableToJsonConverter

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
@@ -17,6 +17,7 @@ import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.gen.api.model.Stream;
 import com.symphony.bdk.gen.api.model.V4AttachmentInfo;
 import com.symphony.bdk.gen.api.model.V4Message;
+import com.symphony.bdk.gen.api.model.V4MessageBlastResponse;
 import com.symphony.bdk.gen.api.model.V4Stream;
 import com.symphony.bdk.workflow.swadl.SwadlParser;
 import com.symphony.bdk.workflow.swadl.v1.Workflow;
@@ -302,6 +303,10 @@ class SendMessageIntegrationTest extends IntegrationTest {
   void sendBlastMessage() throws Exception {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/message/send-blast-message.swadl.yaml"));
+
+    V4MessageBlastResponse response = new V4MessageBlastResponse();
+    response.addMessagesItem(new V4Message());
+    when(messageService.send(eq(List.of("ABC", "DEF")), any())).thenReturn(response);
 
     engine.deploy(workflow);
     engine.onEvent(messageReceived("/send-blast"));

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/swadl/VariableDeserializersTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/swadl/VariableDeserializersTest.java
@@ -1,0 +1,141 @@
+package com.symphony.bdk.workflow.swadl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.symphony.bdk.workflow.engine.camunda.variable.EscapedJsonVariableDeserializer;
+import com.symphony.bdk.workflow.swadl.v1.Variable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This test mimics the conversion between:
+ * SWADL -> Java model -> BPMN -> expression resolution -> Java model (executors)
+ */
+class VariableDeserializersTest {
+
+  private ObjectMapper swadlToModelMapper;
+  private ObjectMapper bpmnToModelMapper;
+
+  @BeforeEach
+  void setUp() {
+    swadlToModelMapper = new ObjectMapper();
+    swadlToModelMapper.registerModule(
+        new SimpleModule().addDeserializer(Variable.class, new VariableListDeserializer()));
+
+    bpmnToModelMapper = new ObjectMapper();
+    bpmnToModelMapper.registerModule(
+        new SimpleModule().addDeserializer(Variable.class, new EscapedJsonVariableDeserializer()));
+  }
+
+  @Test
+  void variableToList() throws JsonProcessingException {
+    Variable<List<String>> swadlModel = swadlToModelMapper.readValue("\"${variables.aVar}\"", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn.replace("${variables.aVar}", "[\\\"ABC\\\"]");
+    Variable<List<String>> modelInExecutor = bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isEqualTo(List.of("ABC"));
+  }
+
+  @Test
+  void listToList() throws JsonProcessingException {
+    Variable<List<String>> swadlModel = swadlToModelMapper.readValue("[\"ABC\"]", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn;
+    Variable<List<String>> modelInExecutor = bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isEqualTo(List.of("ABC"));
+  }
+
+  @Test
+  void variableToMap() throws JsonProcessingException {
+    Variable<Map<String, String>> swadlModel =
+        swadlToModelMapper.readValue("\"${variables.aVar}\"", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn.replace("${variables.aVar}", "{\\\"key\\\":\\\"value\\\"}");
+    Variable<Map<String, String>> modelInExecutor =
+        bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isEqualTo(Map.of("key", "value"));
+  }
+
+  @Test
+  void mapToMap() throws JsonProcessingException {
+    Variable<Map<String, String>> swadlModel =
+        swadlToModelMapper.readValue("{\"key\":\"value\"}", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn;
+    Variable<Map<String, String>> modelInExecutor =
+        bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isEqualTo(Map.of("key", "value"));
+  }
+
+  @Test
+  void variableToNumber() throws JsonProcessingException {
+    Variable<Number> swadlModel = swadlToModelMapper.readValue("\"${variables.aVar}\"", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn.replace("${variables.aVar}", "123");
+    Variable<Number> modelInExecutor = bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isEqualTo(123);
+  }
+
+  @Test
+  void numberToNumber() throws JsonProcessingException {
+    Variable<Number> swadlModel = swadlToModelMapper.readValue("123", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn;
+    Variable<Number> modelInExecutor = bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isEqualTo(123);
+  }
+
+  @Test
+  void variableToBoolean() throws JsonProcessingException {
+    Variable<Boolean> swadlModel = swadlToModelMapper.readValue("\"${variables.aVar}\"", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn.replace("${variables.aVar}", "true");
+    Variable<Boolean> modelInExecutor = bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isTrue();
+  }
+
+  @Test
+  void booleanToBoolean() throws JsonProcessingException {
+    Variable<Boolean> swadlModel = swadlToModelMapper.readValue("true", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn;
+    Variable<Boolean> modelInExecutor = bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isTrue();
+  }
+
+  @Test
+  void variableToString() throws JsonProcessingException {
+    Variable<String> swadlModel = swadlToModelMapper.readValue("\"${variables.aVar}\"", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn.replace("${variables.aVar}", "val");
+    Variable<String> modelInExecutor = bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isEqualTo("val");
+  }
+
+  @Test
+  void stringToString() throws JsonProcessingException {
+    Variable<String> swadlModel = swadlToModelMapper.readValue("\"val\"", new TypeReference<>() {});
+    String swadlModelInBpmn = bpmnToModelMapper.writeValueAsString(swadlModel);
+    String resolvedExpression = swadlModelInBpmn;
+    Variable<String> modelInExecutor = bpmnToModelMapper.readValue(resolvedExpression, new TypeReference<>() {});
+
+    assertThat(modelInExecutor.get()).isEqualTo("val");
+  }
+}

--- a/workflow-bot-app/src/test/resources/application-test.yaml
+++ b/workflow-bot-app/src/test/resources/application-test.yaml
@@ -8,7 +8,7 @@ logging:
   level:
     org.camunda: INFO
     # disable BPMN image generation
-    com.symphony.bdk.workflow.engine.camunda.bpmn.CamundaBpmnBuilder: DEBUG
+    com.symphony.bdk.workflow.engine.camunda.bpmn.CamundaBpmnBuilder: INFO
 
 # disable file watcher for tests
 workflows:

--- a/workflow-bot-app/src/test/resources/message/send-blast-message.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/send-blast-message.swadl.yaml
@@ -1,4 +1,8 @@
 id: send-blast-message
+variables:
+  rooms:
+    - ABC
+    - DEF
 activities:
   - send-message:
       id: sendMessageWithUserIds
@@ -6,7 +10,5 @@ activities:
         message-received:
           content: /send-blast
       to:
-        stream-ids:
-          - ABC
-          - DEF
+        stream-ids: ${variables.rooms}
       content: "<messageML>hello</messageML>"

--- a/workflow-bot-app/src/test/resources/user/add-user-role.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/add-user-role.swadl.yaml
@@ -6,7 +6,7 @@ activities:
         message-received:
           content: /update-user
       user-ids:
-        - "123"
+        - 123
       roles:
         - ADMINISTRATOR
         - AGENT

--- a/workflow-bot-app/src/test/resources/user/get-users-ids.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/get-users-ids.swadl.yaml
@@ -6,8 +6,8 @@ activities:
         message-received:
           content: /get-users
       user-ids:
-        - "123"
-        - "456"
+        - 123
+        - 456
       local: true
       active: false
   - execute-script:

--- a/workflow-bot-app/src/test/resources/user/remove-user-role.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/remove-user-role.swadl.yaml
@@ -6,7 +6,7 @@ activities:
         message-received:
           content: /update-user
       user-ids:
-        - "123"
-        - "456"
+        - 123
+        - 456
       roles:
         - ADMINISTRATOR

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/Variable.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/Variable.java
@@ -1,0 +1,49 @@
+package com.symphony.bdk.workflow.swadl.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class Variable<T> {
+  public static final String RESOLVED_VALUE_FIELD = "val";
+  public static final String VARIABLE_REFERENCE_FIELD = "var";
+
+  @JsonProperty(Variable.RESOLVED_VALUE_FIELD)
+  private T resolvedValue;
+
+  @SuppressWarnings("unused")
+  @JsonProperty(VARIABLE_REFERENCE_FIELD)
+  private String variableReference;
+
+  public static <T> Variable<T> nullValue() {
+    return new Variable<>(null);
+  }
+
+  public static <T> Variable<T> value(T value) {
+    return new Variable<>(value);
+  }
+
+  public Variable(String variableReference) {
+    this.variableReference = variableReference;
+  }
+
+  public Variable(T resolvedValue) {
+    this.resolvedValue = resolvedValue;
+  }
+
+  @JsonIgnore
+  public T get() {
+    return resolvedValue;
+  }
+
+  @JsonIgnore
+  public Integer getInt() {
+    if (resolvedValue instanceof Number) {
+      return ((Number) resolvedValue).intValue();
+    } else {
+      return null;
+    }
+  }
+
+}

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/BaseActivity.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/BaseActivity.java
@@ -35,27 +35,6 @@ public abstract class BaseActivity {
   @Nullable
   private Object elseCondition;
 
-  /**
-   * We usually want unset fields to stay null as the API is usually using default values.
-   *
-   * @param field a Boolean value.
-   * @return null if field is null.
-   */
-  protected static Boolean toBoolean(String field) {
-    return field == null ? null : Boolean.valueOf(field);
-  }
-
-  /**
-   * We usually want unset fields to stay null as the API is usually using default values.
-   *
-   * @param field an Integer value.
-   * @return null if field is null.
-   */
-  protected static Integer toInt(String field) {
-    return field == null ? null : Integer.valueOf(field);
-  }
-
-
   @JsonIgnore
   public List<Event> getEvents() {
     if (on != null && on.getOneOf() != null) {

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/SendMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/SendMessage.java
@@ -1,5 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -13,12 +15,14 @@ public class SendMessage extends BaseActivity {
   @Nullable private To to;
   @Nullable private List<Attachment> attachments;
 
+
   @Data
   public static class To {
     @Nullable private String streamId;
-    @Nullable private List<String> streamIds;
-    @Nullable private List<String> userIds;
+    @Nullable private Variable<List<String>> streamIds;
+    @Nullable private Variable<List<Number>> userIds;
   }
+
 
   @Data
   public static class Attachment {

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/GetConnections.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/GetConnections.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.connection;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import lombok.Data;
@@ -13,6 +14,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class GetConnections extends BaseActivity {
-  private List<String> userIds;
+  private Variable<List<Number>> userIds = Variable.value(List.of());
   private String status;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/GetMessages.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/GetMessages.java
@@ -1,12 +1,10 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.message;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
-import javax.annotation.Nullable;
 
 /**
  * @see <a href="https://developers.symphony.com/restapi/reference#messages-v4">Messages API</a>
@@ -17,16 +15,6 @@ import javax.annotation.Nullable;
 public class GetMessages extends BaseActivity {
   private String streamId;
   private String since;
-  @Nullable private String skip;
-  @Nullable private String limit;
-
-  @JsonIgnore
-  public Integer getSkipAsInt() {
-    return toInt(skip);
-  }
-
-  @JsonIgnore
-  public Integer getLimitAsInt() {
-    return toInt(limit);
-  }
+  private Variable<Number> skip = Variable.nullValue();
+  private Variable<Number> limit = Variable.nullValue();
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/AddRoomMember.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/AddRoomMember.java
@@ -1,11 +1,11 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -15,5 +15,5 @@ import java.util.List;
 @Data
 public class AddRoomMember extends BaseActivity {
   private String streamId;
-  private List<String> userIds = Collections.emptyList();
+  private Variable<List<Number>> userIds = Variable.value(List.of());
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -7,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -21,8 +21,8 @@ import javax.annotation.Nullable;
 public class CreateRoom extends BaseActivity {
   @Nullable private String roomName;
   @Nullable private String roomDescription;
-  @Nullable private List<String> userIds;
-  @Nullable private Map<String, String> keywords;
+  private Variable<List<Number>> userIds = Variable.nullValue();
+  @Nullable private Variable<Map<String, String>> keywords;
   @Nullable private String membersCanInvite;
   @Nullable private String discoverable;
   @Nullable private String readOnly;
@@ -33,20 +33,17 @@ public class CreateRoom extends BaseActivity {
   @Nullable private String subType;
 
   @JsonProperty("public")
-  private String isPublic;
+  private Variable<Boolean> isPublic = Variable.nullValue();
 
-  // to support the usage of variables
   @JsonIgnore
+  @Nullable
   public List<Long> getUserIdsAsLongs() {
-    if (userIds == null) {
-      return Collections.emptyList();
+    if (userIds.get() == null) {
+      return null;
     }
-    return userIds.stream().map(Long::parseLong).collect(Collectors.toList());
-  }
-
-  @JsonIgnore
-  public Boolean isPublicAsBool() {
-    return Boolean.valueOf(isPublic);
+    return userIds.get().stream()
+        .map(Number::longValue)
+        .collect(Collectors.toList());
   }
 }
 

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/DemoteRoomOwner.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/DemoteRoomOwner.java
@@ -1,11 +1,11 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -15,5 +15,5 @@ import java.util.List;
 @Data
 public class DemoteRoomOwner extends BaseActivity {
   private String streamId;
-  private List<String> userIds = Collections.emptyList();
+  private Variable<List<Number>> userIds = Variable.value(List.of());
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRooms.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRooms.java
@@ -1,8 +1,8 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -17,11 +17,11 @@ import javax.annotation.Nullable;
 @Data
 public class GetRooms extends BaseActivity {
   private String query;
-  @Nullable private List<String> labels;
-  @Nullable private String active;
+  private Variable<List<String>> labels = Variable.nullValue();
+  private Variable<Boolean> active = Variable.nullValue();
 
   @JsonProperty("private")
-  @Nullable private String isPrivate;
+  private Variable<Boolean> isPrivate = Variable.nullValue();
 
   @Nullable private String creatorId;
   @Nullable private String ownerId;
@@ -29,27 +29,7 @@ public class GetRooms extends BaseActivity {
 
   @Nullable private String sortOrder;
 
-  @Nullable private String limit;
-  @Nullable private String skip;
-
-  @JsonIgnore
-  public Boolean getActiveAsBool() {
-    return toBoolean(active);
-  }
-
-  @JsonIgnore
-  public Boolean getIsPrivateAsBool() {
-    return toBoolean(isPrivate);
-  }
-
-  @JsonIgnore
-  public Integer getLimitAsInt() {
-    return toInt(limit);
-  }
-
-  @JsonIgnore
-  public Integer getSkipAsInt() {
-    return toInt(skip);
-  }
+  @Nullable private Variable<Number> limit;
+  @Nullable private Variable<Number> skip;
 
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/PromoteRoomOwner.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/PromoteRoomOwner.java
@@ -1,11 +1,11 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -15,5 +15,5 @@ import java.util.List;
 @Data
 public class PromoteRoomOwner extends BaseActivity {
   private String streamId;
-  private List<String> userIds = Collections.emptyList();
+  private Variable<List<Number>> userIds = Variable.value(List.of());
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/RemoveRoomMember.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/RemoveRoomMember.java
@@ -1,11 +1,11 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -16,5 +16,5 @@ import java.util.List;
 @Data
 public class RemoveRoomMember extends BaseActivity {
   private String streamId;
-  private List<String> userIds = Collections.emptyList();
+  private Variable<List<Number>> userIds = Variable.value(List.of());
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/UpdateRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/UpdateRoom.java
@@ -1,8 +1,8 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,7 +13,6 @@ import javax.annotation.Nullable;
 /**
  * @see <a href="https://developers.symphony.com/restapi/reference#update-room-v3">Update room API</a>
  * @see <a href="https://developers.symphony.com/restapi/reference#de-or-re-activate-room">Activate room API</a>
- *
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -22,64 +21,19 @@ public class UpdateRoom extends BaseActivity {
 
   @Nullable private String roomName;
   @Nullable private String roomDescription;
-  @Nullable private Map<String, String> keywords;
+  @Nullable private Variable<Map<String, String>> keywords;
 
-  @Nullable private String membersCanInvite;
-  @Nullable private String discoverable;
+  private Variable<Boolean> membersCanInvite = Variable.nullValue();
+  private Variable<Boolean> discoverable = Variable.nullValue();
 
   @JsonProperty("public")
-  @Nullable private String isPublic;
+  private Variable<Boolean> isPublic = Variable.nullValue();
 
-  @Nullable private String readOnly;
-  @Nullable private String copyProtected;
-  @Nullable private String crossPod;
-  @Nullable private String viewHistory;
-  @Nullable private String multilateralRoom;
+  private Variable<Boolean> readOnly = Variable.nullValue();
+  private Variable<Boolean> copyProtected = Variable.nullValue();
+  private Variable<Boolean> crossPod = Variable.nullValue();
+  private Variable<Boolean> viewHistory = Variable.nullValue();
+  private Variable<Boolean> multilateralRoom = Variable.nullValue();
 
-  @Nullable private String active;
-
-  @JsonIgnore
-  public Boolean getMembersCanInviteAsBool() {
-    return toBoolean(membersCanInvite);
-  }
-
-  @JsonIgnore
-  public Boolean getDiscoverableAsBool() {
-    return toBoolean(discoverable);
-  }
-
-  @JsonIgnore
-  public Boolean getIsPublicAsBool() {
-    return toBoolean(isPublic);
-  }
-
-  @JsonIgnore
-  public Boolean getReadOnlyAsBool() {
-    return toBoolean(readOnly);
-  }
-
-  @JsonIgnore
-  public Boolean getCopyProtectedAsBool() {
-    return toBoolean(copyProtected);
-  }
-
-  @JsonIgnore
-  public Boolean getCrossPodAsBool() {
-    return toBoolean(crossPod);
-  }
-
-  @JsonIgnore
-  public Boolean getViewHistoryAsBool() {
-    return toBoolean(viewHistory);
-  }
-
-  @JsonIgnore
-  public Boolean getMultilateralRoomAsBool() {
-    return toBoolean(multilateralRoom);
-  }
-
-  @JsonIgnore
-  public Boolean getActiveAsBool() {
-    return toBoolean(active);
-  }
+  @Nullable private Variable<Boolean> active;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetStreamMembers.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetStreamMembers.java
@@ -1,8 +1,8 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.stream;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -15,16 +15,6 @@ import javax.annotation.Nullable;
 @Data
 public class GetStreamMembers extends BaseActivity {
   private String streamId;
-  @Nullable private String limit;
-  @Nullable private String skip;
-
-  @JsonIgnore
-  public Integer getLimitAsInt() {
-    return toInt(limit);
-  }
-
-  @JsonIgnore
-  public Integer getSkipAsInt() {
-    return toInt(skip);
-  }
+  @Nullable private Variable<Number> limit;
+  @Nullable private Variable<Number> skip;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetStreams.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetStreams.java
@@ -1,12 +1,13 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.stream;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * @see <a href="https://developers.symphony.com/restapi/reference#list-streams-for-enterprise-v2">Get streams API</a>
@@ -14,23 +15,14 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class GetStreams extends BaseActivity {
-  private List<String> types;
+  @Nullable private Variable<List<String>> types;
   private String scope;
   private String origin;
   private String privacy;
   private String status;
   private String startDate;
   private String endDate;
-  private String limit;
-  private String skip;
+  private Variable<Number> limit;
+  private Variable<Number> skip;
 
-  @JsonIgnore
-  public Integer getLimitAsInt() {
-    return toInt(limit);
-  }
-
-  @JsonIgnore
-  public Integer getSkipAsInt() {
-    return toInt(skip);
-  }
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetUserStreams.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetUserStreams.java
@@ -1,8 +1,8 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.stream;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -14,23 +14,9 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class GetUserStreams extends BaseActivity {
-  private List<String> types;
-  private String includeInactiveStreams;
-  private String limit;
-  private String skip;
+  private Variable<List<String>> types;
+  private Variable<Boolean> includeInactiveStreams = Variable.nullValue();
+  private Variable<Number> limit;
+  private Variable<Number> skip;
 
-  @JsonIgnore
-  public Boolean getIncludeInactiveStreamsAsBool() {
-    return toBoolean(includeInactiveStreams);
-  }
-
-  @JsonIgnore
-  public Integer getLimitAsInt() {
-    return toInt(limit);
-  }
-
-  @JsonIgnore
-  public Integer getSkipAsInt() {
-    return toInt(skip);
-  }
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/AddUserRole.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/AddUserRole.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.user;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import lombok.Data;
@@ -13,6 +14,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class AddUserRole extends BaseActivity {
-  private List<String> userIds;
-  private List<String> roles;
+  private Variable<List<Number>> userIds = Variable.value(List.of());
+  private Variable<List<String>> roles = Variable.value(List.of());
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/CreateUser.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/CreateUser.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.user;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import lombok.Data;
@@ -33,10 +34,10 @@ public class CreateUser extends BaseActivity {
   private Business business;
 
   @Nullable
-  private List<String> roles;
+  private Variable<List<String>> roles = Variable.nullValue();
 
   @Nullable
-  private Map<String, Boolean> entitlements;
+  private Variable<Map<String, Boolean>> entitlements;
 
   @Nullable
   private String status;
@@ -46,6 +47,7 @@ public class CreateUser extends BaseActivity {
 
   @Nullable
   private Keys keys;
+
 
   @Data
   public static class Contact {
@@ -64,13 +66,14 @@ public class CreateUser extends BaseActivity {
     private String title;
     private String location;
     private String jobFunction;
-    private List<String> assetClasses;
-    private List<String> industries;
-    private List<String> functions;
-    private List<String> marketCoverages;
-    private List<String> responsibilities;
-    private List<String> instruments;
+    private Variable<List<String>> assetClasses = Variable.nullValue();
+    private Variable<List<String>> industries = Variable.nullValue();
+    private Variable<List<String>> functions = Variable.nullValue();
+    private Variable<List<String>> marketCoverages = Variable.nullValue();
+    private Variable<List<String>> responsibilities = Variable.nullValue();
+    private Variable<List<String>> instruments = Variable.nullValue();
   }
+
 
   @Data
   public static class Password {
@@ -80,11 +83,13 @@ public class CreateUser extends BaseActivity {
     private String hashedKmSalt;
   }
 
+
   @Data
   public static class Keys {
     private Key current;
     private Key previous;
   }
+
 
   @Data
   public static class Key {

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/GetUsers.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/GetUsers.java
@@ -1,8 +1,8 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.user;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -17,27 +17,13 @@ import javax.annotation.Nullable;
 public class GetUsers extends BaseActivity {
 
   @Nullable
-  private List<String> userIds;
+  private Variable<List<Number>> userIds;
   @Nullable
-  private List<String> emails;
+  private Variable<List<String>> emails;
   @Nullable
-  private List<String> usernames;
+  private Variable<List<String>> usernames;
 
-  @Nullable
-  private String local;
+  private Variable<Boolean> local = Variable.nullValue();
+  private Variable<Boolean> active = Variable.nullValue();
 
-  @Nullable
-  private String active;
-
-  @Nullable
-  @JsonIgnore
-  public Boolean getLocalAsBool() {
-    return toBoolean(local);
-  }
-
-  @Nullable
-  @JsonIgnore
-  public Boolean getActiveAsBool() {
-    return toBoolean(active);
-  }
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/RemoveUserRole.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/RemoveUserRole.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.user;
 
+import com.symphony.bdk.workflow.swadl.v1.Variable;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import lombok.Data;
@@ -13,6 +14,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class RemoveUserRole extends BaseActivity {
-  private List<String> userIds;
-  private List<String> roles;
+  private Variable<List<Number>> userIds = Variable.value(List.of());
+  private Variable<List<String>> roles = Variable.value(List.of());
 }

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1166,7 +1166,20 @@
         },
         "keywords": {
             "description": "A list of key-value pairs, describing additional properties of the room.",
-            "type": "object"
+            "oneOf": [
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "string",
+                    "minLength": 1
+                },
+                {
+                    "enum": [
+                        "${variables.VARIABLE_NAME}"
+                    ]
+                }
+            ]
         },
         "members-can-invite": {
             "description": "If true, any chat room participant can add new participants. If false, only owners can add new participants.",
@@ -1567,108 +1580,192 @@
                     ]
                 },
                 "asset-classes": {
-                    "type": "array",
                     "description": "The user's asset classes (one or more).",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "Equities",
-                            "Cash Equities",
-                            "Securities Lending",
-                            "Fixed Income",
-                            "Government Bonds",
-                            "Prime Brokerage",
-                            "Commodities",
-                            "Municipal Bonds",
-                            "Currencies",
-                            "Corporate Bonds"
-                        ]
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "Equities",
+                                    "Cash Equities",
+                                    "Securities Lending",
+                                    "Fixed Income",
+                                    "Government Bonds",
+                                    "Prime Brokerage",
+                                    "Commodities",
+                                    "Municipal Bonds",
+                                    "Currencies",
+                                    "Corporate Bonds"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "industries": {
-                    "type": "array",
                     "description": "The user's job industries (one or more).",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "Healthcare",
-                            "Consumer Non-Cyclicals",
-                            "Transportation",
-                            "Technology",
-                            "Real Estate",
-                            "Basic Materials",
-                            "Financials",
-                            "Energy & Utilities",
-                            "Conglomerates",
-                            "Consumer Cyclicals",
-                            "Services"
-                        ]
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "Healthcare",
+                                    "Consumer Non-Cyclicals",
+                                    "Transportation",
+                                    "Technology",
+                                    "Real Estate",
+                                    "Basic Materials",
+                                    "Financials",
+                                    "Energy & Utilities",
+                                    "Conglomerates",
+                                    "Consumer Cyclicals",
+                                    "Services"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "functions": {
-                    "type": "array",
                     "description": "The user's job functions (one or more).",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "Collateral",
-                            "Confirmation",
-                            "Trade Processing",
-                            "Pre-Matching",
-                            "Margin",
-                            "Matching",
-                            "Claims Processing",
-                            "Middle Office",
-                            "Liquidity Management",
-                            "Allocation",
-                            "Trade Management",
-                            "Regulatory Outreach",
-                            "Settlements",
-                            "Post Trade Management"
-                        ]
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "Collateral",
+                                    "Confirmation",
+                                    "Trade Processing",
+                                    "Pre-Matching",
+                                    "Margin",
+                                    "Matching",
+                                    "Claims Processing",
+                                    "Middle Office",
+                                    "Liquidity Management",
+                                    "Allocation",
+                                    "Trade Management",
+                                    "Regulatory Outreach",
+                                    "Settlements",
+                                    "Post Trade Management"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "market-coverages": {
-                    "type": "array",
                     "description": "The user's market coverage (one or more).",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "EMEA",
-                            "NA",
-                            "APAC",
-                            "LATAM"
-                        ]
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "EMEA",
+                                    "NA",
+                                    "APAC",
+                                    "LATAM"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "responsibilities": {
-                    "type": "array",
                     "description": "The user's responsibilities (one or more).",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "BAU",
-                            "Escalation"
-                        ]
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "BAU",
+                                    "Escalation"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "instruments": {
-                    "type": "array",
                     "description": "The user's instruments (one or more).",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "Securities",
-                            "Fixed Income",
-                            "Equities"
-                        ]
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "Securities",
+                                    "Fixed Income",
+                                    "Equities"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 }
             }
         },
@@ -1853,336 +1950,377 @@
             }
         },
         "entitlements-inner": {
-            "type": "object",
             "description": "Feature entitlements to configure for the user.",
-            "properties": {
-                "postReadEnabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to read wall posts."
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "postReadEnabled": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to read wall posts."
+                        },
+                        "postWriteEnabled": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to write wall posts."
+                        },
+                        "delegatesEnabled": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to have delegates."
+                        },
+                        "isExternalIMEnabled": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to chat in external IM/MIMs."
+                        },
+                        "canShareFilesExternally": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to share files externally."
+                        },
+                        "canCreatePublicRoom": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to create internal public rooms."
+                        },
+                        "canUpdateAvatar": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to edit profile picture."
+                        },
+                        "isExternalRoomEnabled": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to chat in private external rooms."
+                        },
+                        "canCreatePushedSignals": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to create push signals."
+                        },
+                        "canUseCompactMode": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Enables Lite Mode."
+                        },
+                        "mustBeRecorded": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Must be recorded in meetings."
+                        },
+                        "sendFilesEnabled": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to send files internally."
+                        },
+                        "canUseInternalAudio": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to use audio in internal Meetings."
+                        },
+                        "canUseInternalVideo": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to use video in internal Meetings."
+                        },
+                        "canProjectInternalScreenShare": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to share screens in internal Meetings."
+                        },
+                        "canViewInternalScreenShare": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to view shared screens in internal Meetings."
+                        },
+                        "canCreateMultiLateralRoom": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to create multi-lateral room."
+                        },
+                        "canJoinMultiLateralRoom": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to join multi-lateral room."
+                        },
+                        "canUseFirehose": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to use Firehose."
+                        },
+                        "canUseInternalAudioMobile": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to use audio in internal meetings on mobile."
+                        },
+                        "canUseInternalVideoMobile": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to use video in internal meetings on mobile."
+                        },
+                        "canProjectInternalScreenShareMobile": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to share screens in internal meetings on mobile."
+                        },
+                        "canViewInternalScreenShareMobile": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to view shared screens in internal meetings on mobile."
+                        },
+                        "canManageSignalSubscription": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allows the user to manage signal subscriptions."
+                        },
+                        "canCreateDatahose": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Can create datahose feeds."
+                        },
+                        "canIntegrateEmail": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Can integrate email service."
+                        },
+                        "canReadDatahose": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Can read from datahose feeds."
+                        },
+                        "canSuppressMessage": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Can suppress own messages."
+                        },
+                        "canSwitchToClient20": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Can switch to Client 2.0 experience."
+                        },
+                        "canUpdateRoomHistoryProperty": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Can Toggle Room's Share History Property."
+                        },
+                        "canUseEncryptAPI": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allow user to use Agent Encrypt endpoints."
+                        },
+                        "enableSwiftSearch": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Can Use Swift Search."
+                        },
+                        "sdaDevtoolsEnabled": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Enable Developer Tools for SDA."
+                        },
+                        "sdaPermissionsFullScreen": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Enable Full screen access on SDA."
+                        },
+                        "sdaPermissionsGeoLocation": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Enable location access on SDA."
+                        },
+                        "sdaPermissionsMedia": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Enable Media access on SDA."
+                        },
+                        "sdaPermissionsMidiSysex": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Enable access to MIDI Sysex on SDA."
+                        },
+                        "sdaPermissionsNotifications": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allow notifications on SDA."
+                        },
+                        "sdaPermissionsOpenExternalApp": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Allow Opening External Apps from SDA."
+                        },
+                        "sdaPermissionsPointerLock": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "description": "Enable Pointer Lock on SDA."
+                        }
+                    }
                 },
-                "postWriteEnabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to write wall posts."
+                {
+                    "type": "string",
+                    "minLength": 1
                 },
-                "delegatesEnabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to have delegates."
-                },
-                "isExternalIMEnabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to chat in external IM/MIMs."
-                },
-                "canShareFilesExternally": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to share files externally."
-                },
-                "canCreatePublicRoom": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to create internal public rooms."
-                },
-                "canUpdateAvatar": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to edit profile picture."
-                },
-                "isExternalRoomEnabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to chat in private external rooms."
-                },
-                "canCreatePushedSignals": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to create push signals."
-                },
-                "canUseCompactMode": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Enables Lite Mode."
-                },
-                "mustBeRecorded": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Must be recorded in meetings."
-                },
-                "sendFilesEnabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to send files internally."
-                },
-                "canUseInternalAudio": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to use audio in internal Meetings."
-                },
-                "canUseInternalVideo": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to use video in internal Meetings."
-                },
-                "canProjectInternalScreenShare": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to share screens in internal Meetings."
-                },
-                "canViewInternalScreenShare": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to view shared screens in internal Meetings."
-                },
-                "canCreateMultiLateralRoom": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to create multi-lateral room."
-                },
-                "canJoinMultiLateralRoom": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to join multi-lateral room."
-                },
-                "canUseFirehose": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to use Firehose."
-                },
-                "canUseInternalAudioMobile": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to use audio in internal meetings on mobile."
-                },
-                "canUseInternalVideoMobile": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to use video in internal meetings on mobile."
-                },
-                "canProjectInternalScreenShareMobile": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to share screens in internal meetings on mobile."
-                },
-                "canViewInternalScreenShareMobile": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to view shared screens in internal meetings on mobile."
-                },
-                "canManageSignalSubscription": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allows the user to manage signal subscriptions."
-                },
-                "canCreateDatahose": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Can create datahose feeds."
-                },
-                "canIntegrateEmail": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Can integrate email service."
-                },
-                "canReadDatahose": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Can read from datahose feeds."
-                },
-                "canSuppressMessage": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Can suppress own messages."
-                },
-                "canSwitchToClient20": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Can switch to Client 2.0 experience."
-                },
-                "canUpdateRoomHistoryProperty": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Can Toggle Room's Share History Property."
-                },
-                "canUseEncryptAPI": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allow user to use Agent Encrypt endpoints."
-                },
-                "enableSwiftSearch": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Can Use Swift Search."
-                },
-                "sdaDevtoolsEnabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Enable Developer Tools for SDA."
-                },
-                "sdaPermissionsFullScreen": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Enable Full screen access on SDA."
-                },
-                "sdaPermissionsGeoLocation": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Enable location access on SDA."
-                },
-                "sdaPermissionsMedia": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Enable Media access on SDA."
-                },
-                "sdaPermissionsMidiSysex": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Enable access to MIDI Sysex on SDA."
-                },
-                "sdaPermissionsNotifications": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allow notifications on SDA."
-                },
-                "sdaPermissionsOpenExternalApp": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Allow Opening External Apps from SDA."
-                },
-                "sdaPermissionsPointerLock": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ],
-                    "description": "Enable Pointer Lock on SDA."
+                {
+                    "enum": [
+                        "${variables.VARIABLE_NAME}"
+                    ]
                 }
-            }
+            ]
         },
         "roles-inner": {
-            "type": "array",
             "description": "The roles object consists of the following possibilities:\nFor end-user accounts: INDIVIDUAL, ADMINISTRATOR, SUPER_ADMINISTRATOR, L1_SUPPORT, L2_SUPPORT, COMPLIANCE_OFFICER, SUPER_COMPLIANCE_OFFICER\nFor service accounts: INDIVIDUAL, USER_PROVISIONING, SCOPE_MANAGEMENT, CONTENT_MANAGEMENT, MALWARE_SCAN_MANAGER, MALWARE_SCAN_STATE_USER, AUDIT_TRAIL_MANAGEMENT",
             "x-intellij-html-description": "<html><p>The roles object consists of the following possibilities:<li>For end-user accounts: INDIVIDUAL, ADMINISTRATOR, SUPER_ADMINISTRATOR, L1_SUPPORT, L2_SUPPORT, COMPLIANCE_OFFICER, SUPER_COMPLIANCE_OFFICER</li><li>For service accounts: INDIVIDUAL, USER_PROVISIONING, SCOPE_MANAGEMENT, CONTENT_MANAGEMENT, MALWARE_SCAN_MANAGER, MALWARE_SCAN_STATE_USER, AUDIT_TRAIL_MANAGEMENT</li><br/><a href=\"https://developers.symphony.com/restapi/reference#roles-object\">https://developers.symphony.com/restapi/reference#roles-object</a></p></html>",
-            "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "enum": [
-                    "INDIVIDUAL",
-                    "ADMINISTRATOR",
-                    "SUPER_ADMINISTRATOR",
-                    "L1_SUPPORT",
-                    "L2_SUPPORT",
-                    "COMPLIANCE_OFFICER",
-                    "SUPER_COMPLIANCE_OFFICER",
-                    "USER_PROVISIONING",
-                    "SCOPE_MANAGEMENT",
-                    "CONTENT_MANAGEMENT",
-                    "MALWARE_SCAN_MANAGER",
-                    "MALWARE_SCAN_STATE_USER",
-                    "AUDIT_TRAIL_MANAGEMENT",
-                    "AGENT",
-                    "CONTENT_EXPORT_SERVICE",
-                    "SYMPHONY_ADMIN",
-                    "KEY_MANAGER",
-                    "EF_POLICY_MANAGEMENT",
-                    "CEP_VISIBILITY_GROUP_MANAGEMENT"
-                ]
-            }
+            "oneOf": [
+                {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "INDIVIDUAL",
+                            "ADMINISTRATOR",
+                            "SUPER_ADMINISTRATOR",
+                            "L1_SUPPORT",
+                            "L2_SUPPORT",
+                            "COMPLIANCE_OFFICER",
+                            "SUPER_COMPLIANCE_OFFICER",
+                            "USER_PROVISIONING",
+                            "SCOPE_MANAGEMENT",
+                            "CONTENT_MANAGEMENT",
+                            "MALWARE_SCAN_MANAGER",
+                            "MALWARE_SCAN_STATE_USER",
+                            "AUDIT_TRAIL_MANAGEMENT",
+                            "AGENT",
+                            "CONTENT_EXPORT_SERVICE",
+                            "SYMPHONY_ADMIN",
+                            "KEY_MANAGER",
+                            "EF_POLICY_MANAGEMENT",
+                            "CEP_VISIBILITY_GROUP_MANAGEMENT"
+                        ]
+                    }
+                },
+                {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^\\$\\{.*\\}$"
+                },
+                {
+                    "enum": [
+                        "${variables.VARIABLE_NAME}"
+                    ]
+                }
+            ]
         },
         "user-role-inner": {
             "type": "object",
             "properties": {
                 "user-ids": {
-                    "type": "array",
                     "description": "Users to add or remove roles from.",
-                    "uniqueItems": true,
-                    "minItems": 1,
-                    "items": {
-                        "type": [
-                            "string",
-                            "integer"
-                        ],
-                        "minLength": 1
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "roles": {
                     "$ref": "#/definitions/roles-inner"
@@ -2211,20 +2349,48 @@
                     "$ref": "#/definitions/user-ids-inner"
                 },
                 "emails": {
-                    "type": "array",
                     "description": "List of email addresses. Note that for this activity, you can use either the user-ids, the emails or the usernames, but only one at a time, you cannot mix and match them.",
-                    "items": {
-                        "$ref": "#/definitions/email"
-                    },
-                    "minLength": 1
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/email"
+                            },
+                            "minLength": 1
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "usernames": {
-                    "type": "array",
                     "description": "List of usernames. If username is specified, local must be set to true. Note that for this activity, you can use either the user-ids, the emails or the usernames, but only one at a time, you cannot mix and match them.",
-                    "items": {
-                        "$ref": "#/definitions/name"
-                    },
-                    "minLength": 1
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            },
+                            "minLength": 1
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "local": {
                     "type": [
@@ -2323,16 +2489,30 @@
             "properties": {
                 "types": {
                     "description": "A list of stream types that will be returned. Options are IM (1-1 instant messages), MIM (multiparty instant messages), ROOM (rooms), POST (the user's wall). For more information, see the streamTypes section below.\nIf not specified, all types of streams are returned.",
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "IM",
-                            "MIM",
-                            "ROOM",
-                            "POST"
-                        ]
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IM",
+                                    "MIM",
+                                    "ROOM",
+                                    "POST"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "include-inactive-streams": {
                     "type": [
@@ -2372,15 +2552,29 @@
             "properties": {
                 "types": {
                     "description": "A list of stream types that will be returned (IM, MIM, ROOM). If not specified, streams of all types are returned.",
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "IM",
-                            "MIM",
-                            "ROOM"
-                        ]
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IM",
+                                    "MIM",
+                                    "ROOM"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "scope": {
                     "type": "string",
@@ -2438,11 +2632,25 @@
                     "minLength": 1
                 },
                 "labels": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "A list of room keywords whose values will be queried."
+                    "description": "A list of room keywords whose values will be queried.",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 },
                 "active": {
                     "type": [
@@ -2658,12 +2866,26 @@
             "description": "Stream ids to sent the message to (blast message).",
             "properties": {
                 "stream-ids": {
-                    "type": "array",
-                    "minLength": 1,
-                    "items": {
-                        "type": "string"
-                    },
-                    "uniqueItems": true
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "minLength": 1,
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
                 }
             },
             "required": [
@@ -2672,12 +2894,26 @@
         },
         "user-ids-inner": {
             "description": "User identifiers list.",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/user-id"
-            },
-            "minLength": 1,
-            "uniqueItems": true
+            "oneOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user-id"
+                    },
+                    "minLength": 1,
+                    "uniqueItems": true
+                },
+                {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^\\$\\{.*\\}$"
+                },
+                {
+                    "enum": [
+                        "${variables.VARIABLE_NAME}"
+                    ]
+                }
+            ]
         },
         "user-ids": {
             "type": "object",


### PR DESCRIPTION
In activity attributes with type list or map it was not possible to use
variable references (${}).

How are variables handled in workflows?

In SWADL you use them with ${}
When SWADL is deserialized to the Java model, strings were used
The Java model activity is serialized to JSON and stored in BPMN
When the BPMN is executed, expression (including variables) are
resolved and real values are replaced.
When the CamundaExecutor runs, the JSON activity is deserialised and the
Java mode rebuilt to be used in the Activity executor.

We now use a custom Jackson deserializer to be able to store in the Java
model either a resolved value or a variable reference (i.e the Variable
class).

We then use a custom TypeConverter during expression resolution (juel)
in Camunda to store complex objects (list,map) as escaped JSON.

When we deserialize to rebuild the Java model in CamundaExecutor another
custom deserializer is used to parse this escaped JSON and preserve the
complex objects.

Activities that have attributes other than strings should wrap them in
Variable<?>. Given JSON only support a generic number type, it is
difficult to differentiate a float/integer/long so it is up to the
activity developer to handle it.

The schema has been changed to allow to use variables or lists or maps
for the attributes that support it.