### PR TITLE
Made use of all fields in create-room

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/CreateRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/CreateRoomExecutor.java
@@ -25,7 +25,6 @@ public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
     List<Long> uids = activity.getUserIdsAsLongs();
     String name = activity.getRoomName();
     String description = activity.getRoomDescription();
-    Boolean isPublic = activity.getIsPublic().get();
 
     final String createdRoomId;
 
@@ -47,18 +46,18 @@ public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
     V3RoomAttributes v3RoomAttributes = new V3RoomAttributes()
         .name(createRoom.getRoomName())
         .description(createRoom.getRoomDescription())
-        ._public(createRoom.isPublicAsBool())
-        .viewHistory(createRoom.isViewHistoryAsBool())
-        .discoverable(createRoom.isDiscoverableAsBool())
-        .readOnly(createRoom.isReadOnlyAsBool())
-        .copyProtected(createRoom.isCopyProtectedAsBool())
-        .crossPod(createRoom.isCrossPodAsBool())
-        .multiLateralRoom(createRoom.isMultiLateralRoomAsBool())
-        .membersCanInvite(createRoom.isMembersCanInviteAsBool())
+        ._public(createRoom.getIsPublic().get())
+        .viewHistory(createRoom.getViewHistory().get())
+        .discoverable(createRoom.getDiscoverable().get())
+        .readOnly(createRoom.getReadOnly().get())
+        .copyProtected(createRoom.getCopyProtected().get())
+        .crossPod(createRoom.getCrossPod().get())
+        .multiLateralRoom(createRoom.getMultiLateralRoom().get())
+        .membersCanInvite(createRoom.getMembersCanInvite().get())
         .subType(createRoom.getSubType());
 
     if (createRoom.getKeywords() != null) {
-      for (Map.Entry<String, String> entry : createRoom.getKeywords().entrySet()) {
+      for (Map.Entry<String, String> entry : createRoom.getKeywords().get().entrySet()) {
         v3RoomAttributes.addKeywordsItem(
             new RoomTag()
                 .key(entry.getKey())
@@ -74,9 +73,7 @@ public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
     return stream.getId();
   }
 
-  private String createRoom(ActivityExecutorContext execution, String name, String description, boolean isPublic) {
-    V3RoomAttributes v3RoomAttributes = new V3RoomAttributes();
-    v3RoomAttributes.name(name).description(description)._public(isPublic);
+  private String createRoom(ActivityExecutorContext execution, V3RoomAttributes v3RoomAttributes) {
     V3RoomDetail v3RoomDetail = execution.bdk().streams().create(v3RoomAttributes);
     return v3RoomDetail.getRoomSystemInfo().getId();
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/CreateRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/CreateRoomExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.room;
 
+import com.symphony.bdk.gen.api.model.RoomTag;
 import com.symphony.bdk.gen.api.model.Stream;
 import com.symphony.bdk.gen.api.model.V3RoomAttributes;
 import com.symphony.bdk.gen.api.model.V3RoomDetail;
@@ -11,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
@@ -23,22 +25,47 @@ public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
     List<Long> uids = activity.getUserIdsAsLongs();
     String name = activity.getRoomName();
     String description = activity.getRoomDescription();
-    boolean isPublic = activity.isPublicAsBool();
 
     final String createdRoomId;
 
     if (uids != null && !uids.isEmpty() && !StringUtils.isEmpty(name) && !StringUtils.isEmpty(description)) {
-      createdRoomId = this.createRoom(execution, uids, name, description, isPublic);
+      createdRoomId = this.createRoom(execution, uids, toRoomAttributes(activity));
       log.debug("Stream {} created with {} users, id={}", name, uids.size(), createdRoomId);
     } else if (uids != null && !uids.isEmpty()) {
       createdRoomId = this.createRoom(execution, uids);
       log.debug("MIM created with {} users, id={}", uids.size(), createdRoomId);
     } else {
-      createdRoomId = this.createRoom(execution, name, description, isPublic);
+      createdRoomId = this.createRoom(execution, toRoomAttributes(activity));
       log.debug("Stream {} created, id={}", name, createdRoomId);
     }
 
     execution.setOutputVariable(OUTPUT_ROOM_ID_KEY, createdRoomId);
+  }
+
+  private V3RoomAttributes toRoomAttributes(CreateRoom createRoom) {
+    V3RoomAttributes v3RoomAttributes = new V3RoomAttributes()
+        .name(createRoom.getRoomName())
+        .description(createRoom.getRoomDescription())
+        ._public(createRoom.isPublicAsBool())
+        .viewHistory(createRoom.isViewHistoryAsBool())
+        .discoverable(createRoom.isDiscoverableAsBool())
+        .readOnly(createRoom.isReadOnlyAsBool())
+        .copyProtected(createRoom.isCopyProtectedAsBool())
+        .crossPod(createRoom.isCrossPodAsBool())
+        .multiLateralRoom(createRoom.isMultiLateralRoomAsBool())
+        .membersCanInvite(createRoom.isMembersCanInviteAsBool())
+        .subType(createRoom.getSubType());
+
+    if (createRoom.getKeywords() != null) {
+      for (Map.Entry<String, String> entry : createRoom.getKeywords().entrySet()) {
+        v3RoomAttributes.addKeywordsItem(
+            new RoomTag()
+                .key(entry.getKey())
+                .value(entry.getValue()));
+      }
+    }
+
+    return v3RoomAttributes;
   }
 
   private String createRoom(ActivityExecutorContext execution, List<Long> uids) {
@@ -46,16 +73,13 @@ public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
     return stream.getId();
   }
 
-  private String createRoom(ActivityExecutorContext execution, String name, String description, boolean isPublic) {
-    V3RoomAttributes v3RoomAttributes = new V3RoomAttributes();
-    v3RoomAttributes.name(name).description(description)._public(isPublic);
+  private String createRoom(ActivityExecutorContext execution, V3RoomAttributes v3RoomAttributes) {
     V3RoomDetail v3RoomDetail = execution.bdk().streams().create(v3RoomAttributes);
     return v3RoomDetail.getRoomSystemInfo().getId();
   }
 
-  private String createRoom(ActivityExecutorContext execution, List<Long> uids, String name, String description,
-      boolean isPublic) {
-    String roomId = createRoom(execution, name, description, isPublic);
+  private String createRoom(ActivityExecutorContext execution, List<Long> uids, V3RoomAttributes v3RoomAttributes) {
+    String roomId = createRoom(execution, v3RoomAttributes);
     uids.forEach(uid -> execution.bdk().streams().addMemberToRoom(uid, roomId));
     return roomId;
   }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RoomIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RoomIntegrationTest.java
@@ -118,8 +118,8 @@ class RoomIntegrationTest extends IntegrationTest {
     final V3RoomAttributes captorValue = argumentCaptor.getValue();
 
     final V3RoomAttributes expectedRoomAttributes =
-        this.buildRoomAttributes(roomName, roomDescription, isRoomPublic, false, false, false, false, false, false,
-            false, null, null);
+        this.buildRoomAttributes(roomName, roomDescription, isRoomPublic, null, null, null, true, null, null,
+            null, null, null);
     assertRoomAttributes(expectedRoomAttributes, captorValue);
   }
 
@@ -132,17 +132,17 @@ class RoomIntegrationTest extends IntegrationTest {
   }
 
   private void assertRoomAttributes(V3RoomAttributes expected, V3RoomAttributes actual) {
-    assertThat(expected.getName()).isEqualTo(actual.getName());
-    assertThat(expected.getDescription()).isEqualTo(actual.getDescription());
-    assertThat(expected.getPublic()).isEqualTo(actual.getPublic());
-    assertThat(expected.getCopyProtected()).isEqualTo(actual.getCopyProtected());
-    assertThat(expected.getDiscoverable()).isEqualTo(actual.getDiscoverable());
-    assertThat(expected.getCrossPod()).isEqualTo(actual.getCrossPod());
-    assertThat(expected.getKeywords()).isEqualTo(actual.getKeywords());
-    assertThat(expected.getMembersCanInvite()).isEqualTo(actual.getMembersCanInvite());
-    assertThat(expected.getReadOnly()).isEqualTo(actual.getReadOnly());
-    assertThat(expected.getViewHistory()).isEqualTo(actual.getViewHistory());
-    assertThat(expected.getSubType()).isEqualTo(actual.getSubType());
+    assertThat(actual.getName()).isEqualTo(expected.getName());
+    assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+    assertThat(actual.getPublic()).isEqualTo(expected.getPublic());
+    assertThat(actual.getCopyProtected()).isEqualTo(expected.getCopyProtected());
+    assertThat(actual.getDiscoverable()).isEqualTo(expected.getDiscoverable());
+    assertThat(actual.getCrossPod()).isEqualTo(expected.getCrossPod());
+    assertThat(actual.getKeywords()).isEqualTo(expected.getKeywords());
+    assertThat(actual.getMembersCanInvite()).isEqualTo(expected.getMembersCanInvite());
+    assertThat(actual.getReadOnly()).isEqualTo(expected.getReadOnly());
+    assertThat(actual.getViewHistory()).isEqualTo(expected.getViewHistory());
+    assertThat(actual.getSubType()).isEqualTo(expected.getSubType());
   }
 
   private V3RoomDetail buildRoomDetail(String id, String name, String description, boolean isPublic,

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RoomIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RoomIntegrationTest.java
@@ -67,13 +67,14 @@ class RoomIntegrationTest extends IntegrationTest {
     final boolean crossPod = true;
     final boolean copyProtected = true;
     final boolean multilateralRoom = false;
+    final boolean memberCanInvite = true;
     final String subType = "EMAIL";
     final List<RoomTag> keywords =
         Arrays.asList(new RoomTag().key("A").value("AA"), new RoomTag().key("B").value("BB"));
 
     final V3RoomDetail v3RoomDetail =
         this.buildRoomDetail("1234", roomName, roomDescription, isRoomPublic, viewHistory, discoverable, readOnly,
-            crossPod, copyProtected, multilateralRoom, subType, keywords);
+            crossPod, copyProtected, multilateralRoom, memberCanInvite, subType, keywords);
     when(streamService.create(any(V3RoomAttributes.class))).thenReturn(v3RoomDetail);
 
     engine.deploy(workflow);
@@ -86,7 +87,7 @@ class RoomIntegrationTest extends IntegrationTest {
 
     final V3RoomAttributes expectedRoomAttributes =
         this.buildRoomAttributes(roomName, roomDescription, isRoomPublic, viewHistory, discoverable, readOnly, crossPod,
-            copyProtected, multilateralRoom, subType, keywords);
+            copyProtected, multilateralRoom, memberCanInvite, subType, keywords);
     assertRoomAttributes(expectedRoomAttributes, captorValue);
   }
 
@@ -103,7 +104,7 @@ class RoomIntegrationTest extends IntegrationTest {
 
     final V3RoomDetail v3RoomDetail =
         this.buildRoomDetail("1234", roomName, roomDescription, isRoomPublic, null, null, null, null, null, null, null,
-            null);
+            null, null);
     when(streamService.create(any(V3RoomAttributes.class))).thenReturn(v3RoomDetail);
 
     engine.deploy(workflow);
@@ -117,8 +118,8 @@ class RoomIntegrationTest extends IntegrationTest {
     final V3RoomAttributes captorValue = argumentCaptor.getValue();
 
     final V3RoomAttributes expectedRoomAttributes =
-        this.buildRoomAttributes(roomName, roomDescription, isRoomPublic, null, null, null, null, null, null, null,
-            null);
+        this.buildRoomAttributes(roomName, roomDescription, isRoomPublic, false, false, false, false, false, false,
+            false, null, null);
     assertRoomAttributes(expectedRoomAttributes, captorValue);
   }
 
@@ -134,13 +135,19 @@ class RoomIntegrationTest extends IntegrationTest {
     assertThat(expected.getName()).isEqualTo(actual.getName());
     assertThat(expected.getDescription()).isEqualTo(actual.getDescription());
     assertThat(expected.getPublic()).isEqualTo(actual.getPublic());
+    assertThat(expected.getCopyProtected()).isEqualTo(actual.getCopyProtected());
+    assertThat(expected.getDiscoverable()).isEqualTo(actual.getDiscoverable());
+    assertThat(expected.getCrossPod()).isEqualTo(actual.getCrossPod());
+    assertThat(expected.getKeywords()).isEqualTo(actual.getKeywords());
+    assertThat(expected.getMembersCanInvite()).isEqualTo(actual.getMembersCanInvite());
+    assertThat(expected.getReadOnly()).isEqualTo(actual.getReadOnly());
+    assertThat(expected.getViewHistory()).isEqualTo(actual.getViewHistory());
+    assertThat(expected.getSubType()).isEqualTo(actual.getSubType());
   }
 
   private V3RoomDetail buildRoomDetail(String id, String name, String description, boolean isPublic,
-      Boolean viewHistory,
-      Boolean discoverable, Boolean readOnly, Boolean crossPod, Boolean copyProtected, Boolean multilateralRoom,
-      String subType,
-      List<RoomTag> keywords) {
+      Boolean viewHistory, Boolean discoverable, Boolean readOnly, Boolean crossPod, Boolean copyProtected,
+      Boolean multilateralRoom, Boolean memberCanInvite, String subType, List<RoomTag> keywords) {
     V3RoomDetail v3RoomDetail = new V3RoomDetail();
     RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
     roomSystemInfo.setId(id);
@@ -154,6 +161,7 @@ class RoomIntegrationTest extends IntegrationTest {
         .crossPod(crossPod)
         .copyProtected(copyProtected)
         .multiLateralRoom(multilateralRoom)
+        .membersCanInvite(memberCanInvite)
         .subType(subType)
         .keywords(keywords);
     v3RoomDetail.setRoomSystemInfo(roomSystemInfo);
@@ -164,8 +172,7 @@ class RoomIntegrationTest extends IntegrationTest {
 
   private V3RoomAttributes buildRoomAttributes(String name, String description, Boolean isPublic, Boolean viewHistory,
       Boolean discoverable, Boolean readOnly, Boolean crossPod, Boolean copyProtected, Boolean multilateralRoom,
-      String subType,
-      List<RoomTag> keywords) {
+      Boolean memberCanInvite, String subType, List<RoomTag> keywords) {
     V3RoomAttributes expectedRoomAttributes = new V3RoomAttributes();
     return expectedRoomAttributes.name(name)
         .description(description)
@@ -177,6 +184,7 @@ class RoomIntegrationTest extends IntegrationTest {
         .multiLateralRoom(multilateralRoom)
         .copyProtected(copyProtected)
         .subType(subType)
+        .membersCanInvite(memberCanInvite)
         .keywords(keywords);
   }
 

--- a/workflow-bot-app/src/test/resources/room/create-room-with-details-members.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/create-room-with-details-members.swadl.yaml
@@ -12,3 +12,4 @@ activities:
       room-name: "The best room ever"
       room-description: "this is room description"
       public: false
+      cross-pod: true

--- a/workflow-bot-app/src/test/resources/room/create-room-with-details.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/create-room-with-details.swadl.yaml
@@ -10,13 +10,14 @@ activities:
       public: true
       view-history: true
       keywords:
-        A: AA
-        B: BB
+        "A": "AA"
+        "B": "BB"
       discoverable: false
       read-only: true
       copy-protected: true
       cross-pod: true
       multilateral-room: false
+      members-can-invite: true
       sub-type: EMAIL
 
 

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
@@ -11,6 +11,7 @@ import lombok.EqualsAndHashCode;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nullable;
 
 /**
@@ -23,13 +24,13 @@ public class CreateRoom extends BaseActivity {
   @Nullable private String roomDescription;
   private Variable<List<Number>> userIds = Variable.nullValue();
   @Nullable private Variable<Map<String, String>> keywords;
-  @Nullable private String membersCanInvite;
-  @Nullable private String discoverable;
-  @Nullable private String readOnly;
-  @Nullable private String copyProtected;
-  @Nullable private String crossPod;
-  @Nullable private String viewHistory;
-  @Nullable private String multiLateralRoom;
+  private Variable<Boolean> membersCanInvite = Variable.nullValue();
+  private Variable<Boolean> discoverable = Variable.nullValue();
+  private Variable<Boolean> readOnly = Variable.nullValue();
+  private Variable<Boolean> copyProtected = Variable.nullValue();
+  private Variable<Boolean> crossPod = Variable.nullValue();
+  private Variable<Boolean> viewHistory = Variable.nullValue();
+  private Variable<Boolean> multiLateralRoom = Variable.nullValue();
   @Nullable private String subType;
 
   @JsonProperty("public")
@@ -44,48 +45,6 @@ public class CreateRoom extends BaseActivity {
     return userIds.get().stream()
         .map(Number::longValue)
         .collect(Collectors.toList());
-  }
-
-  @JsonIgnore
-  @Nullable
-  public Boolean isMembersCanInviteAsBool() {
-    return Boolean.valueOf(membersCanInvite);
-  }
-
-  @JsonIgnore
-  @Nullable
-  public Boolean isDiscoverableAsBool() {
-    return Boolean.valueOf(discoverable);
-  }
-
-  @JsonIgnore
-  @Nullable
-  public Boolean isReadOnlyAsBool() {
-    return Boolean.valueOf(readOnly);
-  }
-
-  @JsonIgnore
-  @Nullable
-  public Boolean isCopyProtectedAsBool() {
-    return Boolean.valueOf(copyProtected);
-  }
-
-  @JsonIgnore
-  @Nullable
-  public Boolean isCrossPodAsBool() {
-    return Boolean.valueOf(crossPod);
-  }
-
-  @JsonIgnore
-  @Nullable
-  public Boolean isViewHistoryAsBool() {
-    return Boolean.valueOf(viewHistory);
-  }
-
-  @JsonIgnore
-  @Nullable
-  public Boolean isMultiLateralRoomAsBool() {
-    return Boolean.valueOf(multiLateralRoom);
   }
 
   @Data

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
@@ -48,5 +48,53 @@ public class CreateRoom extends BaseActivity {
   public Boolean isPublicAsBool() {
     return Boolean.valueOf(isPublic);
   }
+
+  @JsonIgnore
+  @Nullable
+  public Boolean isMembersCanInviteAsBool() {
+    return Boolean.valueOf(membersCanInvite);
+  }
+
+  @JsonIgnore
+  @Nullable
+  public Boolean isDiscoverableAsBool() {
+    return Boolean.valueOf(discoverable);
+  }
+
+  @JsonIgnore
+  @Nullable
+  public Boolean isReadOnlyAsBool() {
+    return Boolean.valueOf(readOnly);
+  }
+
+  @JsonIgnore
+  @Nullable
+  public Boolean isCopyProtectedAsBool() {
+    return Boolean.valueOf(copyProtected);
+  }
+
+  @JsonIgnore
+  @Nullable
+  public Boolean isCrossPodAsBool() {
+    return Boolean.valueOf(crossPod);
+  }
+
+  @JsonIgnore
+  @Nullable
+  public Boolean isViewHistoryAsBool() {
+    return Boolean.valueOf(viewHistory);
+  }
+
+  @JsonIgnore
+  @Nullable
+  public Boolean isMultiLateralRoomAsBool() {
+    return Boolean.valueOf(multiLateralRoom);
+  }
+
+  @Data
+  public static class KeywordItem {
+    private String key;
+    private String value;
+  }
 }
 


### PR DESCRIPTION
In a previous commit, we added some fields that were missing in create-room activity such as memberCanInvite... Or, these fields were only added in the pojo and swadl-schema and were not used in the executor.
In this commit we made use of them in the executor and updated the tests