### PR TITLE
Handle multiple workflows/request-received-event

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngine.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngine.java
@@ -79,7 +79,7 @@ public class CamundaEngine implements WorkflowEngine {
 
     // dispatch event
     try {
-      events.dispatch(toRealTimeEvent(parameters));
+      events.dispatch(toRealTimeEvent(parameters, processDefinition.getName()));
     } catch (PresentationMLParserException e) {
       log.debug("Failed to parse MessageML, should not happen", e);
       throw new RuntimeException(e);
@@ -131,10 +131,11 @@ public class CamundaEngine implements WorkflowEngine {
     }
   }
 
-  private RealTimeEvent<RequestReceivedEvent> toRealTimeEvent(ExecutionParameters parameters) {
+  private RealTimeEvent<RequestReceivedEvent> toRealTimeEvent(ExecutionParameters parameters, String workflowId) {
     RequestReceivedEvent requestReceivedEvent = new RequestReceivedEvent();
-    requestReceivedEvent.setBodyArguments(parameters.getArguments());
+    requestReceivedEvent.setArguments(parameters.getArguments());
     requestReceivedEvent.setToken(parameters.getToken());
+    requestReceivedEvent.setWorkflowId(workflowId);
     return new RealTimeEvent<>(null, requestReceivedEvent);
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
@@ -128,7 +128,7 @@ public class CamundaBpmnBuilder {
     for (Activity activityContainer : workflow.getActivities()) {
       BaseActivity activity = activityContainer.getActivity();
 
-      builder = addIntermediateEvents(eventsToConnect, builder, lastActivity, activity);
+      builder = addIntermediateEvents(eventsToConnect, builder, lastActivity, activity, workflow);
 
       // process events starting the activity
       if (onFormRepliedEvent(activity) && activity.getOn() != null) {
@@ -299,7 +299,8 @@ public class CamundaBpmnBuilder {
   }
 
   private AbstractFlowNodeBuilder<?, ?> addIntermediateEvents(List<AbstractFlowNodeBuilder<?, ?>> eventsToConnect,
-      AbstractFlowNodeBuilder<?, ?> builder, String lastActivity, BaseActivity activity) {
+      AbstractFlowNodeBuilder<?, ?> builder, String lastActivity, BaseActivity activity,
+      Workflow workflow) {
     if (!isFirstActivity(lastActivity) && !activity.getEvents().isEmpty()) {
       for (Event event : activity.getEvents()) {
 
@@ -309,7 +310,7 @@ public class CamundaBpmnBuilder {
           eventsToConnect.add(builder); // will be connected after the activity is created
 
         } else {
-          Optional<String> signalName = eventToMessage.toSignalName(event);
+          Optional<String> signalName = eventToMessage.toSignalName(event, workflow);
           if (signalName.isPresent()) {
             builder = createOrMoveEventGateway(builder);
             builder = builder.intermediateCatchEvent()
@@ -350,7 +351,7 @@ public class CamundaBpmnBuilder {
           builder = timerStartEvent(process.startEvent(), event);
           multipleEvents.add(builder);
         } else {
-          Optional<String> signalName = eventToMessage.toSignalName(event);
+          Optional<String> signalName = eventToMessage.toSignalName(event, workflow);
           if (signalName.isPresent()) {
             builder = process.startEvent()
                 .camundaAsyncBefore()

--- a/workflow-bot-app/src/test/resources/event/request-received2.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/event/request-received2.swadl.yaml
@@ -1,10 +1,10 @@
-id: request-received
+id: request-received2
 activities:
   - send-message:
       id: sendmsg
       to:
         stream-id: "123"
-      content: ${event.args.content}
+      content: Second
       on:
         request-received:
           token: myToken

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/event/RequestReceivedEvent.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/event/RequestReceivedEvent.java
@@ -4,8 +4,15 @@ import lombok.Data;
 
 import java.util.Map;
 
+/**
+ * Not a Datafeed event. Manually created when API calls are made to the bot directly.
+ */
 @Data
 public class RequestReceivedEvent {
-  private Map<String, Object> bodyArguments;
   private String token;
+  private Map<String, Object> arguments;
+  /**
+   * To be able to match a specific workflow when the event is received.
+   */
+  private String workflowId;
 }


### PR DESCRIPTION
If multiple workflows are listening to request-received-event they would
all get triggered because the signal's name is the same for all
workflows.

Making the workflow id part of the signal name solves this issue.