### PR TITLE
PLAT-11374 - Apply FINOS Software Project Blueprint

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct for Symphony Workflow Developer Kit (WDK)
+
+Please see the [Community Code of Conduct](https://www.finos.org/code-of-conduct).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Symphony Workflow Developer Kit (WDK) Contribution and Governance Policies
+
+This document describes the contribution process and governance policies of the FINOS symphony-wdk project.
+The project is also governed by the [Linux Foundation Antitrust Policy](https://www.linuxfoundation.org/antitrust-policy/),
+and the FINOS [IP Policy](https://github.com/finos/community/blob/master/governance/IP-Policy.pdf), [Code of Conduct](https://github.com/finos/community/blob/master/governance/Code-of-Conduct.md),
+[Collaborative Principles](https://github.com/finos/community/blob/master/governance/Collaborative-Principles.md), and
+[Meeting Procedures](https://github.com/finos/community/blob/master/governance/Meeting-Procedures.md).
+
+## Contribution Process
+
+Before making a contribution, please take the following steps:
+1. Check whether there's already an open issue related to your proposed contribution. If there is, join the discussion and propose your contribution there.
+2. If there isn't already a relevant issue, create one, describing your contribution and the problem you're trying to solve.
+3. Respond to any questions or suggestions raised in the issue by other developers.
+4. Fork the project repository and prepare your proposed contribution.
+5. Submit a pull request.
+
+NOTE: All contributors must have a contributor license agreement (CLA) on file with FINOS before their pull requests will be merged. Please review the FINOS [contribution requirements](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530375/Contribution+Compliance+Requirements) and submit (or have your employer submit) the required CLA before submitting a pull request.
+
+## Governance
+
+### Roles
+
+The project community consists of Contributors and Maintainers:
+* A **Contributor** is anyone who submits a contribution to the project. (Contributions may include code, issues, comments, documentation, media, or any combination of the above.)
+* A **Maintainer** is a Contributor who, by virtue of their contribution history, has been given write access to project repositories and may merge approved contributions.
+* The **Lead Maintainer** is the project's interface with the FINOS team and Board. They are responsible for approving [quarterly project reports](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/93225748/Board+Reporting+and+Program+Health+Checks) and communicating on behalf of the project. The Lead Maintainer is elected by a vote of the Maintainers.
+
+### Contribution Rules
+
+Anyone is welcome to submit a contribution to the project. The rules below apply to all contributions. (The key words "MUST", "SHALL", "SHOULD", "MAY", etc. in this document are to be interpreted as described in [IETF RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).)
+
+* All contributions MUST be submitted as pull requests, including contributions by Maintainers.
+* All pull requests SHOULD be reviewed by a Maintainer (other than the Contributor) before being merged.
+* Pull requests for non-trivial contributions SHOULD remain open for a review period sufficient to give all Maintainers a sufficient opportunity to review and comment on them.
+* After the review period, if no Maintainer has an objection to the pull request, any Maintainer MAY merge it.
+* If any Maintainer objects to a pull request, the Maintainers SHOULD try to come to consensus through discussion. If not consensus can be reached, any Maintainer MAY call for a vote on the contribution.
+
+### Maintainer Voting
+
+The Maintainers MAY hold votes only when they are unable to reach consensus on an issue. Any Maintainer MAY call a vote on a contested issue, after which Maintainers SHALL have 36 hours to register their votes. Votes SHALL take the form of "+1" (agree), "-1" (disagree), "+0" (abstain). Issues SHALL be decided by the majority of votes cast. If there is only one Maintainer, they SHALL decide any issue otherwise requiring a Maintainer vote. If a vote is tied, the Lead Maintainer MAY cast an additional tie-breaker vote.
+
+The Maintainers SHALL decide the following matters by consensus or, if necessary, a vote:
+* Contested pull requests
+* Election and removal of the Lead Maintainer
+* Election and removal of Maintainers
+
+All Maintainer votes MUST be carried out transparently, with all discussion and voting occurring in public, either:
+* in comments associated with the relevant issue or pull request, if applicable;
+* on the project mailing list or other official public communication channel; or
+* during a regular, minuted project meeting.
+
+### Maintainer Qualifications
+
+Any Contributor who has made a substantial contribution to the project MAY apply (or be nominated) to become a Maintainer. The existing Maintainers SHALL decide whether to approve the nomination according to the Maintainer Voting process above.
+
+### Changes to this Document
+
+This document MAY be amended by a vote of the Maintainers according to the Maintainer Voting process above.

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,24 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔.
+
+---
+
+## Bug Report
+
+### Steps to Reproduce:
+1. ...step 1 description...
+2. ...step 2 description...
+3. ...step 3 description...
+
+### Expected Result:
+...description of what you expected to see...
+
+### Actual Result:
+...what actually happened, including full exceptions (please include the entire stack trace, including "caused by" entries), log entries, screen shots etc. where appropriate...
+
+### Environment:
+...version and build of the project, OS and runtime versions, virtualised environment (if any), etc. ...
+
+### Additional Context:
+...add any other context about the problem here. If applicable, add screenshots to help explain...

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and may want to implement it 🙂)!
+
+---
+
+## Feature Request
+
+### Description of Problem:
+...what *problem* are you trying to solve that the project doesn't currently solve?
+
+...please resist the temptation to describe your request in terms of a solution.  Job Story form ("When [triggering condition], I want to [motivation/goal], so I can [outcome].") can help ensure you're expressing a problem statement.
+
+### Potential Solutions:
+...clearly and concisely describe what you want to happen. Add any considered drawbacks.
+
+... if you've considered alternatives, clearly and concisely describe those too.

--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -1,0 +1,11 @@
+---
+name: 🤗 Support Question
+about: If you have a question about configuration, usage, etc. 💬
+
+---
+
+## Support Question
+
+...ask your question here.
+
+...be sure to search existing issues since someone might have already asked something similar.

--- a/.github/ISSUE_TEMPLATE/meeting_minutes.md
+++ b/.github/ISSUE_TEMPLATE/meeting_minutes.md
@@ -1,0 +1,51 @@
+---
+name: "\U0001F91D symphony-wdk Meeting Minutes"
+about: To track symphony-wdk meeting agenda and attendance
+title: DD MMM YYYY - symphony-wdk Meeting Minutes
+labels: meeting
+assignees:
+
+---
+
+
+## Date
+YYYYMMDD - time
+
+## Untracked attendees
+- Fullname, Affiliation, (optional) GitHub username
+- ...
+
+## Meeting notices
+- FINOS **Project leads** are responsible for observing the FINOS guidelines for [running project meetings](https://github.com/finos/community/blob/master/governance/Meeting-Procedures.md#run-the-meeting). Project maintainers can find additional resources in the [FINOS Maintainers Cheatsheet](https://odp.finos.org/docs/finos-maintainers-cheatsheet/).
+
+- **All participants** in FINOS project meetings are subject to the [LF Antitrust Policy](https://www.linuxfoundation.org/antitrust-policy/), the [FINOS Community Code of Conduct](https://github.com/finos/community/blob/master/governance/Code-of-Conduct.md) and all other [FINOS policies](https://github.com/finos/community/tree/master/governance#policies).
+
+- FINOS meetings involve participation by industry competitors, and it is the intention of FINOS and the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws. Please contact legal@finos.org with any questions.
+
+- FINOS project meetings may be recorded for use solely by the FINOS team for administration purposes. In very limited instances, and with explicit approval, recordings may be made more widely available.
+
+## Agenda
+- [ ] Convene & roll call (5mins)
+- [ ] Display [FINOS Antitrust Policy summary slide](https://github.com/finos/community/blob/master/governance/Compliance-Slides/Antitrust-Compliance-Slide.pdf)
+- [ ] Review Meeting Notices (see above)
+- [ ] Approve past meeting minutes
+- [ ] Agenda item 1
+- [ ] Agenda item 2
+- [ ] ...
+- [ ] AOB, Q&A & Adjourn (5mins)
+
+## Decisions Made
+- [ ] Decision 1
+- [ ] Decision 2
+- [ ] ...
+
+## Action Items
+- [ ] Action 1
+- [ ] Action 2
+- [ ] ...
+
+### WebEx info
+- Meeting link:
+- Meeting number:
+- Password:
+- Call-in:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### Ticket
+[Ticket number](link to ticket)
+
+### Description
+Please put here the intent of your pull request.
+
+### Dependencies
+List the other pull requests that should be merged before/along this one.
+
+### Checklist
+- [ ] Referenced a ticket in the PR title and in the corresponding section
+- [ ] Filled properly the description and dependencies, if any
+- [ ] Unit/Integration tests updated or added
+- [ ] Javadoc added or updated
+- [ ] Updated the documentation in [docs folder](../docs)

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Symphony Workflow Developer Kit (WDK) - FINOS
+Copyright 2021 Symphony LLC
+
+This product includes software developed at the Fintech Open Source Foundation (https://www.finos.org/).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Incubating)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 # Symphony Workflow Developer Kit (WDK)
 
 _Also known as Workflow API or Workflow bot_, check out the  [documentation](./docs).
@@ -5,28 +8,42 @@ _Also known as Workflow API or Workflow bot_, check out the  [documentation](./d
 :warning: _The WDK is very much in its inception and we are actually looking to get feedback on its usage. It also means
 all the APIs and the SWADL format are subject to change._
 
-## Usage
-
+## Getting started
 Check out the [Getting starting guide](./docs/getting-started.md) for an introduction.
 
-## How to build
+## Usage example
 
+![](../../../licecap.gif)
+
+_For more examples and usage, please refer to the [docs/examples](./docs/examples)._
+
+## Development setup
+
+### Build
 Java (JDK) 11 is required and Gradle is used to build the project.
-
 ```shell
 ./gradlew build
-``` 
+```
+
+### Tests run
+```sh
+./gradlew check
+```
 
 ## Contributing
 
-In order to get in touch with the project team, please open
-a [GitHub Issue](https://github.com/SymphonyPlatformSolutions/symphony-wdk/issues).
-
-1. Fork it
+1. Fork it (<https://github.com/SymphonyPlatformSolutions/symphony-wdk>)
 2. Create your feature branch (`git checkout -b feature/fooBar`)
-3. Commit your changes (`git commit -am 'Add some fooBar'`)
-4. Push to the branch (`git push origin feature/fooBar`)
-5. Create a new Pull Request
+3. Read our [contribution guidelines](.github/CONTRIBUTING.md) and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
+4. Check your code quality (`./gradlew check`)
+5. Commit your changes (`git commit -am 'Add some fooBar'`)
+6. Push to the branch (`git push origin feature/fooBar`)
+7. Create a new Pull Request
+
+_NOTE:_ Commits and pull requests to FINOS repositories will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS OR who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the FINOS Clabot tool (or [EasyCLA](https://github.com/finos/community/blob/master/governance/Software-Projects/EasyCLA.md)). Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.
+
+*Need an ICLA? Unsure if you are covered under an existing CCLA? Email [help@finos.org](mailto:help@finos.org)*
+
 
 ## License
 


### PR DESCRIPTION
Related ticket: [PLAT-11374](https://perzoinc.atlassian.net/browse/PLAT-11374)

Steps required by https://odp.finos.org/docs/project-collaboration/#finos-project-blueprint: 

- [x] A README.md template, with a suggested structure of content
- [x] A NOTICE template, required by FINOS bylaws
- [x] A LICENSE template, required by FINOS bylaws
- [x] A Code of Conduct template, required by FINOS bylaws
- [x] Contributing guidelines, required by FINOS bylaws
- [x] Issue templates for bugs, feature requests and support questions , defined in the .github folder
- [ ] WhiteSource custom configuration, to setup continuous security scanning for your project (Will be done after moving to FINOS)
