### PR TITLE
PLAT-11372: remove undeploy

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/configuration/WorkflowFolderWatcher.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/configuration/WorkflowFolderWatcher.java
@@ -118,10 +118,10 @@ public class WorkflowFolderWatcher {
         addWorkflow(changedFile);
 
       } else if (ev.kind().equals(StandardWatchEventKinds.ENTRY_DELETE)) {
-        removeWorkflow(changedFile);
+        workflowEngine.undeploy(deployedWorkflows.get(changedFile));
+        this.deployedWorkflows.remove(changedFile);
 
       } else if (ev.kind().equals(StandardWatchEventKinds.ENTRY_MODIFY)) {
-        removeWorkflow(changedFile);
         addWorkflow(changedFile);
 
       } else {
@@ -138,13 +138,6 @@ public class WorkflowFolderWatcher {
     Workflow workflow = SwadlParser.fromYaml(workflowFile.toFile());
     workflowEngine.deploy(workflow);
     deployedWorkflows.put(workflowFile, workflow.getId());
-  }
-
-  private void removeWorkflow(Path workflowFile) {
-    if (deployedWorkflows.containsKey(workflowFile)) {
-      workflowEngine.undeploy(deployedWorkflows.get(workflowFile));
-    }
-    deployedWorkflows.remove(workflowFile);
   }
 
   @PreDestroy


### PR DESCRIPTION
### Description
Now that the workflow id is required, when a swadl file is changed, the previous deployed version is not used anymore for new executions but only for pending ones. For this reason, WorkflowFolderWatcher does not need anymore to undeploy a workflow when the file changed. Calling undeploy method is still required when a swadl file is deleted.

### Checklist
- [x] Referenced a ticket in the PR title or description
- [x] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
